### PR TITLE
(GH-27) Add NewIssue alias

### DIFF
--- a/src/Cake.Issues/Aliases.cs
+++ b/src/Cake.Issues/Aliases.cs
@@ -12,6 +12,45 @@
     public static class Aliases
     {
         /// <summary>
+        /// Initiates the creation of a new <see cref="IIssue"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="message">The message of the issue.</param>
+        /// <param name="providerType">The unique identifier of the issue provider.</param>
+        /// <param name="providerName">The human friendly name of the issue provider.</param>
+        /// <returns>Builder class for creating a new <see cref="IIssue"/>.</returns>
+        /// <example>
+        /// <para>Create a new warning for the myfile.txt file on line 42:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var issue =
+        ///         NewIssue(
+        ///             "Something went wrong"
+        ///             "MyCakeScript"
+        ///             "My Cake Script")
+        ///             .InFile("myfile.txt", 42)
+        ///             .WithPriority(IssuePriority.Warning)
+        ///             .Create();
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.CreateCakeAliasCategory)]
+        public static IssueBuilder NewIssue(
+            this ICakeContext context,
+            string message,
+            string providerType,
+            string providerName)
+        {
+            context.NotNull(nameof(context));
+            message.NotNullOrWhiteSpace(nameof(message));
+            providerType.NotNullOrWhiteSpace(nameof(providerType));
+            providerName.NotNullOrWhiteSpace(nameof(providerName));
+
+            return IssueBuilder.NewIssue(message, providerType, providerName);
+        }
+
+        /// <summary>
         /// Reads issues from a single issue provider.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Issues/IssuesAliasConstants.cs
+++ b/src/Cake.Issues/IssuesAliasConstants.cs
@@ -11,6 +11,11 @@
         public const string MainCakeAliasCategory = "Issues";
 
         /// <summary>
+        /// Category to use for all Cake aliases providing functionality for creating issues.
+        /// </summary>
+        public const string CreateCakeAliasCategory = "Creating Issues";
+
+        /// <summary>
         /// Category to use for all Cake aliases providing functionality for reading issues.
         /// </summary>
         public const string ReadCakeAliasCategory = "Reading Issues";


### PR DESCRIPTION
Add alias for creating issues inside Cake build script without an issue provider, which can also be used for creating reports or reporting to pull requests.

Fixes #27