### PR TITLE
 (GH-121) Support message in multiple format on issues 

### DIFF
--- a/src/Cake.Issues.Testing/BaseIssueProviderFixture.cs
+++ b/src/Cake.Issues.Testing/BaseIssueProviderFixture.cs
@@ -33,13 +33,13 @@
         public RepositorySettings RepositorySettings { get; set; }
 
         /// <summary>
-        /// Calls <see cref="BaseIssueProvider.ReadIssues(IssueCommentFormat)"/>.
+        /// Calls <see cref="BaseIssueProvider.ReadIssues()"/>.
         /// </summary>
         /// <returns>Issues returned from issue provider.</returns>
         public IEnumerable<IIssue> ReadIssues()
         {
             var issueProvider = this.CreateIssueProvider();
-            return issueProvider.ReadIssues(IssueCommentFormat.PlainText);
+            return issueProvider.ReadIssues();
         }
 
         /// <summary>

--- a/src/Cake.Issues.Testing/FakeConfigurableIssueProvider.cs
+++ b/src/Cake.Issues.Testing/FakeConfigurableIssueProvider.cs
@@ -55,18 +55,12 @@
         /// </summary>
         public new IssueProviderSettings IssueProviderSettings => base.IssueProviderSettings;
 
-        /// <summary>
-        /// Gets the format in which issues should be returned.
-        /// </summary>
-        public IssueCommentFormat Format { get; private set; }
-
         /// <inheritdoc/>
         public override string ProviderName => "Fake Issue Provider";
 
         /// <inheritdoc/>
-        protected override IEnumerable<IIssue> InternalReadIssues(IssueCommentFormat format)
+        protected override IEnumerable<IIssue> InternalReadIssues()
         {
-            this.Format = format;
             return this.issues;
         }
     }

--- a/src/Cake.Issues.Testing/FakeIssueProvider.cs
+++ b/src/Cake.Issues.Testing/FakeIssueProvider.cs
@@ -44,18 +44,12 @@
         /// </summary>
         public new RepositorySettings Settings => base.Settings;
 
-        /// <summary>
-        /// Gets the format in which issues should be returned.
-        /// </summary>
-        public IssueCommentFormat Format { get; private set; }
-
         /// <inheritdoc/>
         public override string ProviderName => "Fake Issue Provider";
 
         /// <inheritdoc/>
-        protected override IEnumerable<IIssue> InternalReadIssues(IssueCommentFormat format)
+        protected override IEnumerable<IIssue> InternalReadIssues()
         {
-            this.Format = format;
             return this.issues;
         }
     }

--- a/src/Cake.Issues.Testing/FakeLogFileFormat.cs
+++ b/src/Cake.Issues.Testing/FakeLogFileFormat.cs
@@ -42,7 +42,6 @@
         /// <inheritdoc/>
         public override IEnumerable<IIssue> ReadIssues(
             FakeMultiFormatIssueProvider issueProvider,
-            IssueCommentFormat format,
             RepositorySettings repositorySettings,
             FakeMultiFormatIssueProviderSettings issueProviderSettings)
         {

--- a/src/Cake.Issues.Testing/IssueChecker.cs
+++ b/src/Cake.Issues.Testing/IssueChecker.cs
@@ -45,7 +45,9 @@
                 expectedIssue.ProjectName,
                 expectedIssue.AffectedFileRelativePath?.ToString(),
                 expectedIssue.Line,
-                expectedIssue.Message,
+                expectedIssue.MessageText,
+                expectedIssue.MessageHtml,
+                expectedIssue.MessageMarkdown,
                 expectedIssue.Priority,
                 expectedIssue.PriorityName,
                 expectedIssue.Rule,
@@ -66,7 +68,9 @@
         /// <c>null</c> if the issue is not expected to be related to a change in a file.</param>
         /// <param name="line">Expected line number.
         /// <c>null</c> if the issue is not expected to be related to a file or specific line.</param>
-        /// <param name="message">Expected message.</param>
+        /// <param name="messageText">Expected message in plain text format.</param>
+        /// <param name="messageHtml">Expected message in HTML format.</param>
+        /// <param name="messageMarkdown">Expected message in Markdown format.</param>
         /// <param name="priority">Expected priority.
         /// <c>null</c> if no priority is expected.</param>
         /// <param name="priorityName">Expected priority name.
@@ -83,7 +87,9 @@
             string projectName,
             string affectedFileRelativePath,
             int? line,
-            string message,
+            string messageText,
+            string messageHtml,
+            string messageMarkdown,
             int? priority,
             string priorityName,
             string rule,
@@ -161,10 +167,22 @@
                     $"Expected issue.Line to be '{line}' but was '{issue.Line}'.");
             }
 
-            if (issue.Message != message)
+            if (issue.MessageText != messageText)
             {
                 throw new Exception(
-                    $"Expected issue.Message to be '{message}' but was '{issue.Message}'.");
+                    $"Expected issue.MessageText to be '{messageText}' but was '{issue.MessageText}'.");
+            }
+
+            if (issue.MessageHtml != messageHtml)
+            {
+                throw new Exception(
+                    $"Expected issue.MessageHtml to be '{messageHtml}' but was '{issue.MessageHtml}'.");
+            }
+
+            if (issue.MessageMarkdown != messageMarkdown)
+            {
+                throw new Exception(
+                    $"Expected issue.MessageMarkdown to be '{messageMarkdown}' but was '{issue.MessageMarkdown}'.");
             }
 
             if (issue.Priority != priority)

--- a/src/Cake.Issues.Tests/BaseIssueProviderTests.cs
+++ b/src/Cake.Issues.Tests/BaseIssueProviderTests.cs
@@ -42,7 +42,7 @@
                 var provider = new FakeIssueProvider(new FakeLog());
 
                 // When
-                var result = Record.Exception(() => provider.ReadIssues(IssueCommentFormat.PlainText));
+                var result = Record.Exception(() => provider.ReadIssues());
 
                 // Then
                 result.IsInvalidOperationException("Initialize needs to be called first.");

--- a/src/Cake.Issues.Tests/BaseMultiFormatIssueProviderTests.cs
+++ b/src/Cake.Issues.Tests/BaseMultiFormatIssueProviderTests.cs
@@ -113,7 +113,7 @@
                 provider.Initialize(new RepositorySettings(@"c:\repo"));
 
                 // When
-                var result = provider.ReadIssues(IssueCommentFormat.PlainText);
+                var result = provider.ReadIssues();
 
                 // Then
                 result.Count().ShouldBe(2);

--- a/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
+++ b/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
@@ -43,6 +43,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Testfiles\issuesV2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Testfiles\issueV2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Testfiles\issue.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
@@ -308,13 +308,17 @@
             [InlineData("foo {Line} bar", "foo 42 bar")]
             [InlineData("foo {Rule} bar", "foo Rule Foo bar")]
             [InlineData("foo {RuleUrl} bar", "foo https://google.com/ bar")]
-            [InlineData("foo {Message} bar", "foo Message Foo bar")]
+            [InlineData("foo {MessageText} bar", "foo MessageText Foo bar")]
+            [InlineData("foo {MessageHtml} bar", "foo MessageHtml Foo bar")]
+            [InlineData("foo {MessageMarkdown} bar", "foo MessageMarkdown Foo bar")]
             public void Should_Replace_Tokens(string pattern, string expectedResult)
             {
                 // Given
                 var issue =
                     IssueBuilder
-                        .NewIssue("Message Foo", "ProviderType Foo", "ProviderName Foo")
+                        .NewIssue("MessageText Foo", "ProviderType Foo", "ProviderName Foo")
+                        .WithMessageInHtmlFormat("MessageHtml Foo")
+                        .WithMessageInMarkdownFormat("MessageMarkdown Foo")
                         .InFile(@"src/Cake.Issues/foo.cs", 42)
                         .InProject(@"src/Cake.Issues/Cake.Issues.csproj", "Cake.Issues")
                         .OfRule("Rule Foo", new Uri("https://google.com"))

--- a/src/Cake.Issues.Tests/IssueBuilderFixture.cs
+++ b/src/Cake.Issues.Tests/IssueBuilderFixture.cs
@@ -7,10 +7,10 @@
         {
         }
 
-        public IssueBuilderFixture(string message, string providerType, string providerName)
+        public IssueBuilderFixture(string messageText, string providerType, string providerName)
         {
             this.IssueBuilder =
-                IssueBuilder.NewIssue(message, providerType, providerName);
+                IssueBuilder.NewIssue(messageText, providerType, providerName);
         }
 
         public IssueBuilder IssueBuilder { get; private set; }

--- a/src/Cake.Issues.Tests/IssueReaderTests.cs
+++ b/src/Cake.Issues.Tests/IssueReaderTests.cs
@@ -20,7 +20,7 @@
                 };
 
                 // When
-                var result = Record.Exception(() => fixture.ReadIssues(IssueCommentFormat.Undefined));
+                var result = Record.Exception(() => fixture.ReadIssues());
 
                 // Then
                 result.IsArgumentNullException("log");
@@ -36,7 +36,7 @@
                 };
 
                 // When
-                var result = Record.Exception(() => fixture.ReadIssues(IssueCommentFormat.Undefined));
+                var result = Record.Exception(() => fixture.ReadIssues());
 
                 // Then
                 result.IsArgumentNullException("issueProviders");
@@ -50,7 +50,7 @@
                 fixture.IssueProviders.Clear();
 
                 // When
-                var result = Record.Exception(() => fixture.ReadIssues(IssueCommentFormat.Undefined));
+                var result = Record.Exception(() => fixture.ReadIssues());
 
                 // Then
                 result.IsArgumentException("issueProviders");
@@ -65,7 +65,7 @@
                 fixture.IssueProviders.Add(null);
 
                 // When
-                var result = Record.Exception(() => fixture.ReadIssues(IssueCommentFormat.Undefined));
+                var result = Record.Exception(() => fixture.ReadIssues());
 
                 // Then
                 result.IsArgumentOutOfRangeException("issueProviders");
@@ -81,7 +81,7 @@
                 };
 
                 // When
-                var result = Record.Exception(() => fixture.ReadIssues(IssueCommentFormat.Undefined));
+                var result = Record.Exception(() => fixture.ReadIssues());
 
                 // Then
                 result.IsArgumentNullException("settings");
@@ -97,7 +97,7 @@
                 var fixture = new IssuesFixture();
 
                 // When
-                fixture.ReadIssues(IssueCommentFormat.Undefined);
+                fixture.ReadIssues();
 
                 // Then
                 fixture.IssueProviders.ShouldAllBe(x => x.Settings == fixture.Settings);
@@ -147,7 +147,7 @@
                         }));
 
                 // When
-                fixture.ReadIssues(IssueCommentFormat.Undefined);
+                fixture.ReadIssues();
 
                 // Then
                 fixture.IssueProviders.ShouldAllBe(x => x.Settings == fixture.Settings);
@@ -183,7 +183,7 @@
                         }));
 
                 // When
-                var issues = fixture.ReadIssues(IssueCommentFormat.Undefined).ToList();
+                var issues = fixture.ReadIssues().ToList();
 
                 // Then
                 issues.Count.ShouldBe(2);
@@ -219,7 +219,7 @@
                         }));
 
                 // When
-                var issues = fixture.ReadIssues(IssueCommentFormat.Undefined).ToList();
+                var issues = fixture.ReadIssues().ToList();
 
                 // Then
                 issues.Count.ShouldBe(2);
@@ -279,7 +279,7 @@
                         }));
 
                 // When
-                var issues = fixture.ReadIssues(IssueCommentFormat.Undefined).ToList();
+                var issues = fixture.ReadIssues().ToList();
 
                 // Then
                 issues.Count.ShouldBe(4);

--- a/src/Cake.Issues.Tests/IssueTests.cs
+++ b/src/Cake.Issues.Tests/IssueTests.cs
@@ -19,7 +19,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 100;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -34,7 +36,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -56,7 +60,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 100;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -71,7 +77,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -91,7 +99,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -106,7 +116,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -126,7 +138,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -141,7 +155,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -161,7 +177,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -176,7 +194,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -196,7 +216,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -211,7 +233,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -234,7 +258,9 @@
                     string projectName = null;
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -249,7 +275,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -269,7 +297,9 @@
                     var projectName = string.Empty;
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -284,7 +314,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -304,7 +336,9 @@
                     var projectName = " ";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -319,7 +353,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -339,7 +375,9 @@
                     var projectPath = @"src\foo.csproj";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -354,7 +392,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -377,7 +417,9 @@
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var line = 100;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -392,7 +434,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -414,7 +458,9 @@
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var line = 100;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -429,7 +475,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -449,7 +497,9 @@
                     var projectName = "foo";
                     string filePath = null;
                     int? line = null;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -464,7 +514,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -484,7 +536,9 @@
                     var projectName = "foo";
                     var filePath = string.Empty;
                     int? line = null;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -499,7 +553,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -519,7 +575,9 @@
                     var projectName = "foo";
                     var filePath = " ";
                     int? line = null;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -534,7 +592,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -562,7 +622,9 @@
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -577,7 +639,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -601,7 +665,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = -1;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -616,7 +682,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -636,7 +704,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 0;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -651,7 +721,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -671,7 +743,9 @@
                     var projectName = "foo";
                     string filePath = null;
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -686,7 +760,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -708,7 +784,9 @@
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -723,7 +801,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -736,17 +816,19 @@
                 }
             }
 
-            public sealed class TheMessageArgument
+            public sealed class TheMessageTextArgument
             {
                 [Fact]
-                public void Should_Throw_If_Message_Is_Null()
+                public void Should_Throw_If_MessageText_Is_Null()
                 {
                     // Given
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    string message = null;
+                    string messageText = null;
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -761,7 +843,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -770,18 +854,20 @@
                             providerName));
 
                     // Then
-                    result.IsArgumentNullException("message");
+                    result.IsArgumentNullException("messageText");
                 }
 
                 [Fact]
-                public void Should_Throw_If_Message_Is_Empty()
+                public void Should_Throw_If_MessageText_Is_Empty()
                 {
                     // Given
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = string.Empty;
+                    var messageText = string.Empty;
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -796,7 +882,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -805,18 +893,20 @@
                             providerName));
 
                     // Then
-                    result.IsArgumentOutOfRangeException("message");
+                    result.IsArgumentOutOfRangeException("messageText");
                 }
 
                 [Fact]
-                public void Should_Throw_If_Message_Is_WhiteSpace()
+                public void Should_Throw_If_MessageText_Is_WhiteSpace()
                 {
                     // Given
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = " ";
+                    var messageText = " ";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -831,7 +921,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -840,18 +932,20 @@
                             providerName));
 
                     // Then
-                    result.IsArgumentOutOfRangeException("message");
+                    result.IsArgumentOutOfRangeException("messageText");
                 }
 
                 [Theory]
-                [InlineData("message")]
-                public void Should_Set_Message(string message)
+                [InlineData("messageText")]
+                public void Should_Set_MessageText(string messageText)
                 {
                     // Given
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -866,7 +960,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -875,7 +971,97 @@
                             providerName);
 
                     // Then
-                    issue.Message.ShouldBe(message);
+                    issue.MessageText.ShouldBe(messageText);
+                }
+            }
+
+            public sealed class TheMessageHtmlArgument
+            {
+                [Theory]
+                [InlineData(null)]
+                [InlineData("")]
+                [InlineData(" ")]
+                [InlineData("messageHtml")]
+                public void Should_Set_MessageHtml(string messageHtml)
+                {
+                    // Given
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var messageText = "MessageText";
+                    var messageMarkdown = "MessageMarkdown";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+
+                    // When
+                    var issue =
+                        new Issue(
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            providerType,
+                            providerName);
+
+                    // Then
+                    issue.MessageHtml.ShouldBe(messageHtml);
+                }
+            }
+
+            public sealed class TheMessageMarkdownArgument
+            {
+                [Theory]
+                [InlineData(null)]
+                [InlineData("")]
+                [InlineData(" ")]
+                [InlineData("messageMarkdown")]
+                public void Should_Set_MessageHtml(string messageMarkdown)
+                {
+                    // Given
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+
+                    // When
+                    var issue =
+                        new Issue(
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            providerType,
+                            providerName);
+
+                    // Then
+                    issue.MessageMarkdown.ShouldBe(messageMarkdown);
                 }
             }
 
@@ -895,7 +1081,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priorityName = "Warning";
                     var rule = "Rule";
                     var ruleUri = new Uri("https://google.com");
@@ -909,7 +1097,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -932,7 +1122,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     string priorityName = null;
                     var rule = "Rule";
@@ -947,7 +1139,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -967,7 +1161,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = string.Empty;
                     var rule = "Rule";
@@ -982,7 +1178,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1002,7 +1200,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = " ";
                     var rule = "Rule";
@@ -1017,7 +1217,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1038,7 +1240,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var rule = "Rule";
                     var ruleUri = new Uri("https://google.com");
@@ -1052,7 +1256,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1078,7 +1284,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var ruleUri = new Uri("https://google.com");
@@ -1092,7 +1300,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1115,7 +1325,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1130,7 +1342,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1150,7 +1364,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1165,7 +1381,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1188,7 +1406,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1203,7 +1423,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1223,7 +1445,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1238,7 +1462,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1258,7 +1484,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1273,7 +1501,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1294,7 +1524,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1308,7 +1540,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1331,7 +1565,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1346,7 +1582,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1366,7 +1604,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1381,7 +1621,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1401,7 +1643,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1416,7 +1660,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,
@@ -1437,7 +1683,9 @@
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
-                    var message = "Message";
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
                     var priority = 1;
                     var priorityName = "Warning";
                     var rule = "Rule";
@@ -1451,7 +1699,9 @@
                             projectName,
                             filePath,
                             line,
-                            message,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
                             priority,
                             priorityName,
                             rule,

--- a/src/Cake.Issues.Tests/IssuesFixture.cs
+++ b/src/Cake.Issues.Tests/IssuesFixture.cs
@@ -22,10 +22,10 @@
 
         public RepositorySettings Settings { get; set; }
 
-        public IEnumerable<IIssue> ReadIssues(IssueCommentFormat format)
+        public IEnumerable<IIssue> ReadIssues()
         {
             var issueReader = new IssuesReader(this.Log, this.IssueProviders, this.Settings);
-            return issueReader.ReadIssues(format);
+            return issueReader.ReadIssues();
         }
     }
 }

--- a/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
@@ -104,6 +104,30 @@
                         .OfRule("Rule", new Uri("https://google.com"))
                         .WithPriority(IssuePriority.Warning));
             }
+
+            [Fact]
+            public void Should_Return_IssueV2()
+            {
+                // Given
+                var filePath = new FilePath("Testfiles/issueV2.json");
+
+                // When
+                var result = filePath.DeserializeToIssue();
+
+                // Then
+                IssueChecker.Check(
+                    result,
+                    IssueBuilder.NewIssue(
+                        "Something went wrong.",
+                        "TestProvider",
+                        "Test Provider")
+                        .WithMessageInHtmlFormat("Something went <b>wrong</b>.")
+                        .WithMessageInMarkdownFormat("Something went **wrong**.")
+                        .InProject(@"src\Foo\Bar.csproj", "Bar")
+                        .InFile(@"src\Foo\Bar.cs", 42)
+                        .OfRule("Rule", new Uri("https://google.com"))
+                        .WithPriority(IssuePriority.Warning));
+            }
         }
 
         public sealed class TheDeserializeToIssuesExtensionForAJsonFile
@@ -161,6 +185,42 @@
                         "Something went wrong again.",
                         "TestProvider",
                         "Test Provider")
+                        .InProject(@"src\Foo\Bar.csproj", "Bar")
+                        .InFile(@"src\Foo\Bar2.cs")
+                        .WithPriority(IssuePriority.Warning));
+            }
+
+            [Fact]
+            public void Should_Return_List_Of_IssuesV2()
+            {
+                // Given
+                var filePath = new FilePath("Testfiles/issuesV2.json");
+
+                // When
+                var result = filePath.DeserializeToIssues().ToList();
+
+                // Then
+                result.Count.ShouldBe(2);
+                IssueChecker.Check(
+                    result[0],
+                    IssueBuilder.NewIssue(
+                        "Something went wrong.",
+                        "TestProvider",
+                        "Test Provider")
+                        .WithMessageInHtmlFormat("Something went <b>wrong</b>.")
+                        .WithMessageInMarkdownFormat("Something went **wrong**.")
+                        .InProject(@"src\Foo\Bar.csproj", "Bar")
+                        .InFile(@"src\Foo\Bar.cs", 42)
+                        .OfRule("Rule", new Uri("https://google.com"))
+                        .WithPriority(IssuePriority.Warning));
+                IssueChecker.Check(
+                    result[1],
+                    IssueBuilder.NewIssue(
+                        "Something went wrong again.",
+                        "TestProvider",
+                        "Test Provider")
+                        .WithMessageInHtmlFormat("Something went <b>wrong</b> again.")
+                        .WithMessageInMarkdownFormat("Something went **wrong** again.")
                         .InProject(@"src\Foo\Bar.csproj", "Bar")
                         .InFile(@"src\Foo\Bar2.cs")
                         .WithPriority(IssuePriority.Warning));

--- a/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
@@ -27,7 +27,7 @@
             }
 
             [Fact]
-            public void Should_Give_Correct_Result_For_Message_After_Roundtrip()
+            public void Should_Give_Correct_Result_For_MessageText_After_Roundtrip()
             {
                 // Given
                 var message = "message";
@@ -40,7 +40,43 @@
                 var result = issue.SerializeToJsonString().DeserializeToIssue();
 
                 // Then
-                result.Message.ShouldBe(message);
+                result.MessageText.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageMarkdown_After_Roundtrip()
+            {
+                // Given
+                var messageMarkdown = "messageMarkdown";
+                var issue =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .WithMessageInMarkdownFormat(messageMarkdown)
+                        .Create();
+
+                // When
+                var result = issue.SerializeToJsonString().DeserializeToIssue();
+
+                // Then
+                result.MessageMarkdown.ShouldBe(messageMarkdown);
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageHtml_After_Roundtrip()
+            {
+                // Given
+                var messageHtml = "messageHtml";
+                var issue =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .WithMessageInHtmlFormat(messageHtml)
+                        .Create();
+
+                // When
+                var result = issue.SerializeToJsonString().DeserializeToIssue();
+
+                // Then
+                result.MessageHtml.ShouldBe(messageHtml);
             }
 
             [Fact]
@@ -238,19 +274,19 @@
             }
 
             [Fact]
-            public void Should_Give_Correct_Result_For_Message_After_Roundtrip()
+            public void Should_Give_Correct_Result_For_MessageText_After_Roundtrip()
             {
                 // Given
-                var message1 = "message1";
-                var message2 = "message2";
+                var messageText1 = "messageText1";
+                var messageText2 = "messageText2";
                 var issues =
                     new List<IIssue>
                     {
                         IssueBuilder
-                          .NewIssue(message1, "providerType1", "providerName1")
+                          .NewIssue(messageText1, "providerType1", "providerName1")
                             .Create(),
                         IssueBuilder
-                            .NewIssue(message2, "providerType2", "providerName2")
+                            .NewIssue(messageText2, "providerType2", "providerName2")
                             .Create(),
                     };
 
@@ -259,8 +295,64 @@
 
                 // Then
                 result.Count().ShouldBe(2);
-                result.First().Message.ShouldBe(message1);
-                result.Last().Message.ShouldBe(message2);
+                result.First().MessageText.ShouldBe(messageText1);
+                result.Last().MessageText.ShouldBe(messageText2);
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageMarkdown_After_Roundtrip()
+            {
+                // Given
+                var messageMarkdown1 = "messageMarkdown1";
+                var messageMarkdown2 = "messageMarkdown2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue("messageText1", "providerType1", "providerName1")
+                            .WithMessageInMarkdownFormat(messageMarkdown1)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("messageText2", "providerType2", "providerName2")
+                            .WithMessageInMarkdownFormat(messageMarkdown2)
+                            .Create(),
+                    };
+
+                // When
+                var result = issues.SerializeToJsonString().DeserializeToIssues();
+
+                // Then
+                result.Count().ShouldBe(2);
+                result.First().MessageMarkdown.ShouldBe(messageMarkdown1);
+                result.Last().MessageMarkdown.ShouldBe(messageMarkdown2);
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageHtml_After_Roundtrip()
+            {
+                // Given
+                var messageHtml1 = "messageHtml1";
+                var messageHtml2 = "messageHtml2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue("messageText1", "providerType1", "providerName1")
+                            .WithMessageInHtmlFormat(messageHtml1)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("messageText2", "providerType2", "providerName2")
+                            .WithMessageInHtmlFormat(messageHtml2)
+                            .Create(),
+                    };
+
+                // When
+                var result = issues.SerializeToJsonString().DeserializeToIssues();
+
+                // Then
+                result.Count().ShouldBe(2);
+                result.First().MessageHtml.ShouldBe(messageHtml1);
+                result.Last().MessageHtml.ShouldBe(messageHtml2);
             }
 
             [Fact]
@@ -574,13 +666,13 @@
             }
 
             [Fact]
-            public void Should_Give_Correct_Result_For_Message_After_Roundtrip()
+            public void Should_Give_Correct_Result_For_MessageText_After_Roundtrip()
             {
                 // Given
-                var message = "message";
+                var messageText = "messageText";
                 var issue =
                     IssueBuilder
-                        .NewIssue(message, "providerType", "providerName")
+                        .NewIssue(messageText, "providerType", "providerName")
                         .Create();
                 var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
 
@@ -591,7 +683,61 @@
                     var result = filePath.DeserializeToIssue();
 
                     // Then
-                    result.Message.ShouldBe(message);
+                    result.MessageText.ShouldBe(messageText);
+                }
+                finally
+                {
+                    System.IO.File.Delete(filePath.FullPath);
+                }
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageMarkdown_After_Roundtrip()
+            {
+                // Given
+                var messageMarkdown = "messageMarkdown";
+                var issue =
+                    IssueBuilder
+                        .NewIssue("messageText", "providerType", "providerName")
+                        .WithMessageInMarkdownFormat(messageMarkdown)
+                        .Create();
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issue.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssue();
+
+                    // Then
+                    result.MessageMarkdown.ShouldBe(messageMarkdown);
+                }
+                finally
+                {
+                    System.IO.File.Delete(filePath.FullPath);
+                }
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageHtml_After_Roundtrip()
+            {
+                // Given
+                var messageHtml = "messageHtml";
+                var issue =
+                    IssueBuilder
+                        .NewIssue("messageText", "providerType", "providerName")
+                        .WithMessageInHtmlFormat(messageHtml)
+                        .Create();
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issue.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssue();
+
+                    // Then
+                    result.MessageHtml.ShouldBe(messageHtml);
                 }
                 finally
                 {
@@ -899,19 +1045,19 @@
             }
 
             [Fact]
-            public void Should_Give_Correct_Result_For_Message_After_Roundtrip()
+            public void Should_Give_Correct_Result_For_MessageText_After_Roundtrip()
             {
                 // Given
-                var message1 = "message1";
-                var message2 = "message2";
+                var messageText1 = "messageText1";
+                var messageText2 = "messageText2";
                 var issues =
                     new List<IIssue>
                     {
                         IssueBuilder
-                          .NewIssue(message1, "providerType1", "providerName1")
+                          .NewIssue(messageText1, "providerType1", "providerName1")
                             .Create(),
                         IssueBuilder
-                            .NewIssue(message2, "providerType2", "providerName2")
+                            .NewIssue(messageText2, "providerType2", "providerName2")
                             .Create(),
                     };
                 var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
@@ -924,8 +1070,82 @@
 
                     // Then
                     result.Count().ShouldBe(2);
-                    result.First().Message.ShouldBe(message1);
-                    result.Last().Message.ShouldBe(message2);
+                    result.First().MessageText.ShouldBe(messageText1);
+                    result.Last().MessageText.ShouldBe(messageText2);
+                }
+                finally
+                {
+                    System.IO.File.Delete(filePath.FullPath);
+                }
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageMarkdown_After_Roundtrip()
+            {
+                // Given
+                var messageMarkdown1 = "messageMarkdown1";
+                var messageMarkdown2 = "messageMarkdown2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue("messageText1", "providerType1", "providerName1")
+                            .WithMessageInMarkdownFormat(messageMarkdown1)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("messageText2", "providerType2", "providerName2")
+                            .WithMessageInMarkdownFormat(messageMarkdown2)
+                            .Create(),
+                    };
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issues.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssues();
+
+                    // Then
+                    result.Count().ShouldBe(2);
+                    result.First().MessageMarkdown.ShouldBe(messageMarkdown1);
+                    result.Last().MessageMarkdown.ShouldBe(messageMarkdown2);
+                }
+                finally
+                {
+                    System.IO.File.Delete(filePath.FullPath);
+                }
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_MessageHtml_After_Roundtrip()
+            {
+                // Given
+                var messageHtml1 = "messageHtml1";
+                var messageHtml2 = "messageHtml2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue("messageText1", "providerType1", "providerName1")
+                            .WithMessageInHtmlFormat(messageHtml1)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("messageText2", "providerType2", "providerName2")
+                            .WithMessageInHtmlFormat(messageHtml2)
+                            .Create(),
+                    };
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issues.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssues();
+
+                    // Then
+                    result.Count().ShouldBe(2);
+                    result.First().MessageHtml.ShouldBe(messageHtml1);
+                    result.Last().MessageHtml.ShouldBe(messageHtml2);
                 }
                 finally
                 {

--- a/src/Cake.Issues.Tests/Serialization/SerializableIssueV2ExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/SerializableIssueV2ExtensionsTests.cs
@@ -1,0 +1,25 @@
+﻿namespace Cake.Issues.Tests.Serialization
+{
+    using Cake.Issues.Serialization;
+    using Cake.Issues.Testing;
+    using Xunit;
+
+    public sealed class SerializableIssueV2ExtensionsTests
+    {
+        public sealed class TheToIssueExtension
+        {
+            [Fact]
+            public void Should_Throw_If_SerializableIssue_Is_Null()
+            {
+                // Given
+                SerializableIssueV2 serializableIssue = null;
+
+                // When
+                var result = Record.Exception(() => serializableIssue.ToIssue());
+
+                // Then
+                result.IsArgumentNullException("serializableIssue");
+            }
+        }
+    }
+}

--- a/src/Cake.Issues.Tests/Testfiles/issueV2.json
+++ b/src/Cake.Issues.Tests/Testfiles/issueV2.json
@@ -1,0 +1,16 @@
+{
+  "Version": 2,
+  "AffectedFileRelativePath": "src\/Foo\/Bar.cs",
+  "Line": 42,
+  "MessageText": "Something went wrong.",
+  "MessageHtml": "Something went <b>wrong</b>.",
+  "MessageMarkdown": "Something went **wrong**.",
+  "Priority": 300,
+  "PriorityName": "Warning",
+  "ProjectFileRelativePath": "src\/Foo\/Bar.csproj",
+  "ProjectName": "Bar",
+  "ProviderName": "Test Provider",
+  "ProviderType": "TestProvider",
+  "Rule": "Rule",
+  "RuleUrl": "https://google.com"
+}

--- a/src/Cake.Issues.Tests/Testfiles/issuesV2.json
+++ b/src/Cake.Issues.Tests/Testfiles/issuesV2.json
@@ -1,0 +1,34 @@
+[
+  {
+    "Version": 2,
+    "AffectedFileRelativePath": "src\/Foo\/Bar.cs",
+    "Line": 42,
+    "MessageText": "Something went wrong.",
+    "MessageHtml": "Something went <b>wrong</b>.",
+    "MessageMarkdown": "Something went **wrong**.",
+    "Priority": 300,
+    "PriorityName": "Warning",
+    "ProjectFileRelativePath": "src\/Foo\/Bar.csproj",
+    "ProjectName": "Bar",
+    "ProviderName": "Test Provider",
+    "ProviderType": "TestProvider",
+    "Rule": "Rule",
+    "RuleUrl": "https://google.com"
+  },
+  {
+    "Version": 2,
+    "AffectedFileRelativePath": "src\/Foo\/Bar2.cs",
+    "Line": null,
+    "MessageText": "Something went wrong again.",
+    "MessageHtml": "Something went <b>wrong</b> again.",
+    "MessageMarkdown": "Something went **wrong** again.",
+    "Priority": 300,
+    "PriorityName": "Warning",
+    "ProjectFileRelativePath": "src\/Foo\/Bar.csproj",
+    "ProjectName": "Bar",
+    "ProviderName": "Test Provider",
+    "ProviderType": "TestProvider",
+    "Rule": null,
+    "RuleUrl": null
+  }
+]

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
@@ -9,8 +9,8 @@
         {
         }
 
-        public IssueCheckerFixture(string message, string providerType, string providerName)
-            : base(message, providerType, providerName)
+        public IssueCheckerFixture(string messageText, string providerType, string providerName)
+            : base(messageText, providerType, providerName)
         {
             this.ProviderType = providerType;
             this.ProviderName = providerName;
@@ -18,13 +18,17 @@
             this.ProjectName = "ProjectName";
             this.AffectedFileRelativePath = @"src\source.file";
             this.Line = 42;
-            this.Message = message;
+            this.MessageText = messageText;
+            this.MessageHtml = "messageHtml";
+            this.MessageMarkdown = "messageMarkdown";
             this.Priority = 100;
             this.PriorityName = "PriorityName";
             this.Rule = "Rule";
             this.RuleUrl = new Uri("https://google.com");
 
             this.IssueBuilder
+                .WithMessageInHtmlFormat(this.MessageHtml)
+                .WithMessageInMarkdownFormat(this.MessageMarkdown)
                 .InProject(this.ProjectFileRelativePath, this.ProjectName)
                 .InFile(this.AffectedFileRelativePath, this.Line)
                 .OfRule(this.Rule, this.RuleUrl)
@@ -48,7 +52,11 @@
 
         public int Line { get; private set; }
 
-        public string Message { get; private set; }
+        public string MessageText { get; private set; }
+
+        public string MessageHtml { get; private set; }
+
+        public string MessageMarkdown { get; private set; }
 
         public int Priority { get; private set; }
 

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
@@ -148,7 +148,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -173,7 +175,9 @@
                     fixture.ProjectName,
                     fixture.AffectedFileRelativePath,
                     fixture.Line,
-                    fixture.Message,
+                    fixture.MessageText,
+                    fixture.MessageHtml,
+                    fixture.MessageMarkdown,
                     fixture.Priority,
                     fixture.PriorityName,
                     fixture.Rule,
@@ -202,7 +206,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -233,7 +239,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -265,7 +273,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -300,7 +310,9 @@
                         expectedValue,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -332,7 +344,9 @@
                         fixture.ProjectName,
                         expectedValue,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -366,7 +380,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         expectedValue,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -382,7 +398,7 @@
             [InlineData(null, "Foo")]
             [InlineData("", "Foo")]
             [InlineData(" ", "Foo")]
-            public void Should_Throw_If_Message_Is_Different(string expectedValue, string actualValue)
+            public void Should_Throw_If_MessageText_Is_Different(string expectedValue, string actualValue)
             {
                 // Given
                 var fixture = new IssueCheckerFixture(actualValue, "ProviderType", "ProviderName");
@@ -398,6 +414,8 @@
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
                         expectedValue,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -405,7 +423,81 @@
 
                 // Then
                 result.ShouldBeOfType<Exception>();
-                result.Message.ShouldStartWith("Expected issue.Message");
+                result.Message.ShouldStartWith("Expected issue.MessageText");
+            }
+
+            [Theory]
+            [InlineData("Message", "Foo")]
+            [InlineData(null, "Foo")]
+            [InlineData("", "Foo")]
+            [InlineData(" ", "Foo")]
+            public void Should_Throw_If_MessageHtml_Is_Different(string expectedValue, string actualValue)
+            {
+                // Given
+                var fixture = new IssueCheckerFixture();
+                var issue =
+                    fixture.IssueBuilder
+                        .WithMessageInHtmlFormat(actualValue)
+                        .Create();
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueChecker.Check(
+                        fixture.Issue,
+                        fixture.ProviderType,
+                        fixture.ProviderName,
+                        fixture.ProjectFileRelativePath,
+                        fixture.ProjectName,
+                        fixture.AffectedFileRelativePath,
+                        fixture.Line,
+                        fixture.MessageText,
+                        expectedValue,
+                        fixture.MessageMarkdown,
+                        fixture.Priority,
+                        fixture.PriorityName,
+                        fixture.Rule,
+                        fixture.RuleUrl));
+
+                // Then
+                result.ShouldBeOfType<Exception>();
+                result.Message.ShouldStartWith("Expected issue.MessageHtml");
+            }
+
+            [Theory]
+            [InlineData("Message", "Foo")]
+            [InlineData(null, "Foo")]
+            [InlineData("", "Foo")]
+            [InlineData(" ", "Foo")]
+            public void Should_Throw_If_MessageMarkdown_Is_Different(string expectedValue, string actualValue)
+            {
+                // Given
+                var fixture = new IssueCheckerFixture();
+                var issue =
+                    fixture.IssueBuilder
+                        .WithMessageInMarkdownFormat(actualValue)
+                        .Create();
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueChecker.Check(
+                        fixture.Issue,
+                        fixture.ProviderType,
+                        fixture.ProviderName,
+                        fixture.ProjectFileRelativePath,
+                        fixture.ProjectName,
+                        fixture.AffectedFileRelativePath,
+                        fixture.Line,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        expectedValue,
+                        fixture.Priority,
+                        fixture.PriorityName,
+                        fixture.Rule,
+                        fixture.RuleUrl));
+
+                // Then
+                result.ShouldBeOfType<Exception>();
+                result.Message.ShouldStartWith("Expected issue.MessageMarkdown");
             }
 
             [Theory]
@@ -429,7 +521,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         (int)expectedValue,
                         fixture.PriorityName,
                         fixture.Rule,
@@ -464,7 +558,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         expectedValue,
                         fixture.Rule,
@@ -499,7 +595,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         expectedValue,
@@ -531,7 +629,9 @@
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
                         fixture.Line,
-                        fixture.Message,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
                         fixture.Priority,
                         fixture.PriorityName,
                         fixture.Rule,

--- a/src/Cake.Issues/Aliases.ReadIssues.cs
+++ b/src/Cake.Issues/Aliases.ReadIssues.cs
@@ -182,7 +182,7 @@
             var issuesReader =
                 new IssuesReader(context.Log, issueProviders, settings);
 
-            return issuesReader.ReadIssues(settings.Format);
+            return issuesReader.ReadIssues();
         }
     }
 }

--- a/src/Cake.Issues/BaseIssueProvider.cs
+++ b/src/Cake.Issues/BaseIssueProvider.cs
@@ -21,19 +21,18 @@
         public abstract string ProviderName { get; }
 
         /// <inheritdoc/>
-        public IEnumerable<IIssue> ReadIssues(IssueCommentFormat format)
+        public IEnumerable<IIssue> ReadIssues()
         {
             this.AssertInitialized();
 
-            return this.InternalReadIssues(format);
+            return this.InternalReadIssues();
         }
 
         /// <summary>
         /// Gets all issues.
         /// Compared to <see cref="ReadIssues"/> it is safe to access Settings from this method.
         /// </summary>
-        /// <param name="format">Preferred format of the comments.</param>
         /// <returns>List of issues.</returns>
-        protected abstract IEnumerable<IIssue> InternalReadIssues(IssueCommentFormat format);
+        protected abstract IEnumerable<IIssue> InternalReadIssues();
     }
 }

--- a/src/Cake.Issues/BaseLogFileFormat.cs
+++ b/src/Cake.Issues/BaseLogFileFormat.cs
@@ -31,7 +31,6 @@
         /// <inheritdoc/>
         public abstract IEnumerable<IIssue> ReadIssues(
             TIssueProvider issueProvider,
-            IssueCommentFormat format,
             RepositorySettings repositorySettings,
             TSettings issueProviderSettings);
     }

--- a/src/Cake.Issues/BaseMultiFormatIssueProvider.cs
+++ b/src/Cake.Issues/BaseMultiFormatIssueProvider.cs
@@ -23,12 +23,11 @@
         }
 
         /// <inheritdoc/>
-        protected override IEnumerable<IIssue> InternalReadIssues(IssueCommentFormat format)
+        protected override IEnumerable<IIssue> InternalReadIssues()
         {
             return
                 this.IssueProviderSettings.Format.ReadIssues(
                     (TIssueProvider)this,
-                    format,
                     this.Settings,
                     this.IssueProviderSettings);
         }

--- a/src/Cake.Issues/IIssue.cs
+++ b/src/Cake.Issues/IIssue.cs
@@ -35,9 +35,19 @@
         int? Line { get; }
 
         /// <summary>
-        /// Gets the message of the issue.
+        /// Gets the message of the issue in text format.
         /// </summary>
-        string Message { get; }
+        string MessageText { get; }
+
+        /// <summary>
+        /// Gets the message of the issue in HTML format.
+        /// </summary>
+        string MessageHtml { get; }
+
+        /// <summary>
+        /// Gets the message of the issue in Markdown format.
+        /// </summary>
+        string MessageMarkdown { get; }
 
         /// <summary>
         /// Gets the priority of the message. A higher value indicates a higher priority.

--- a/src/Cake.Issues/IIssueExtensions.cs
+++ b/src/Cake.Issues/IIssueExtensions.cs
@@ -1,10 +1,38 @@
 ﻿namespace Cake.Issues
 {
+    using System;
+
     /// <summary>
     /// Extensions for <see cref="IIssue"/>.
     /// </summary>
     public static class IIssueExtensions
     {
+        /// <summary>
+        /// Gets the message of the issue in a specific format.
+        /// If the message is not available in the specific format, the message in
+        /// text format will be returned.
+        /// </summary>
+        /// <param name="issue">Issue for which the message should be returned.</param>
+        /// <param name="format">Format in which the message should be returned.</param>
+        /// <returns>Message in the format specified by <paramref name="format"/> or message in text
+        /// format if it is not available in the desired format.</returns>
+        public static string Message(this IIssue issue, IssueCommentFormat format)
+        {
+            issue.NotNull(nameof(issue));
+
+            switch (format)
+            {
+                case IssueCommentFormat.PlainText:
+                    return issue.MessageText;
+                case IssueCommentFormat.Html:
+                    return !string.IsNullOrEmpty(issue.MessageHtml) ? issue.MessageHtml : issue.MessageText;
+                case IssueCommentFormat.Markdown:
+                    return !string.IsNullOrEmpty(issue.MessageMarkdown) ? issue.MessageMarkdown : issue.MessageText;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(format));
+            }
+        }
+
         /// <summary>
         /// Returns the full path of <see cref="IIssue.ProjectFileRelativePath"/> or <c>null</c>.
         /// </summary>
@@ -128,8 +156,18 @@
         ///         <description>The value of <see cref="IIssue.RuleUrl"/>.</description>
         ///     </item>
         ///     <item>
-        ///         <term>{Message}</term>
-        ///         <description>The value of <see cref="IIssue.Message"/>.</description>
+        ///         <term>{MessageText}</term>
+        ///         <description>The value of <see cref="IIssue.MessageText"/>.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>{MessageHtml}</term>
+        ///         <description>The value of <see cref="IIssue.MessageHtml"/> or <see cref="IIssue.MessageText"/>
+        ///         if message in HTML format is not available.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>{MessageMarkdown}</term>
+        ///         <description>The value of <see cref="IIssue.MessageMarkdown"/> or <see cref="IIssue.MessageText"/>
+        ///         if message in Markdown format is not available.</description>
         ///     </item>
         /// </list>
         /// </param>
@@ -155,7 +193,9 @@
                     .Replace("{Line}", issue.Line?.ToString())
                     .Replace("{Rule}", issue.Rule)
                     .Replace("{RuleUrl}", issue.RuleUrl?.ToString())
-                    .Replace("{Message}", issue.Message);
+                    .Replace("{MessageText}", issue.Message(IssueCommentFormat.PlainText))
+                    .Replace("{MessageHtml}", issue.Message(IssueCommentFormat.Html))
+                    .Replace("{MessageMarkdown}", issue.Message(IssueCommentFormat.Markdown));
         }
     }
 }

--- a/src/Cake.Issues/IIssueProvider.cs
+++ b/src/Cake.Issues/IIssueProvider.cs
@@ -15,8 +15,7 @@
         /// <summary>
         /// Gets all issues.
         /// </summary>
-        /// <param name="format">Preferred format of the comments.</param>
         /// <returns>List of issues.</returns>
-        IEnumerable<IIssue> ReadIssues(IssueCommentFormat format);
+        IEnumerable<IIssue> ReadIssues();
     }
 }

--- a/src/Cake.Issues/ILogFileFormat.cs
+++ b/src/Cake.Issues/ILogFileFormat.cs
@@ -15,13 +15,11 @@
         /// Gets all issues.
         /// </summary>
         /// <param name="issueProvider">Issue provider instance.</param>
-        /// <param name="format">Preferred format for comments.</param>
         /// <param name="repositorySettings">Repository settings to use.</param>
         /// <param name="issueProviderSettings">Settings for issue provider to use.</param>
         /// <returns>List of issues.</returns>
         IEnumerable<IIssue> ReadIssues(
             TIssueProvider issueProvider,
-            IssueCommentFormat format,
             RepositorySettings repositorySettings,
             TSettings issueProviderSettings);
     }

--- a/src/Cake.Issues/Issue.cs
+++ b/src/Cake.Issues/Issue.cs
@@ -21,7 +21,9 @@
         /// <c>null</c> or <see cref="string.Empty"/> if issue is not related to a change in a file.</param>
         /// <param name="line">The line in the file where the issues has occurred.
         /// <c>null</c> if the issue affects the whole file or an asssembly.</param>
-        /// <param name="message">The message of the issue.</param>
+        /// <param name="messageText">The message of the issue in plain text format.</param>
+        /// <param name="messageHtml">The message of the issue in Html format.</param>
+        /// <param name="messageMarkdown">The message of the issue in Markdown format.</param>
         /// <param name="priority">The priority of the message.
         /// <c>null</c> if no priority was assigned.</param>
         /// <param name="priorityName">The human friendly name of the priority.
@@ -37,7 +39,9 @@
             string projectName,
             string affectedFileRelativePath,
             int? line,
-            string message,
+            string messageText,
+            string messageHtml,
+            string messageMarkdown,
             int? priority,
             string priorityName,
             string rule,
@@ -46,7 +50,7 @@
             string providerName)
         {
             line?.NotNegativeOrZero(nameof(line));
-            message.NotNullOrWhiteSpace(nameof(message));
+            messageText.NotNullOrWhiteSpace(nameof(messageText));
             providerType.NotNullOrWhiteSpace(nameof(providerType));
             providerName.NotNullOrWhiteSpace(nameof(providerName));
 
@@ -93,7 +97,9 @@
 
             this.ProjectName = projectName;
             this.Line = line;
-            this.Message = message;
+            this.MessageText = messageText;
+            this.MessageHtml = messageHtml;
+            this.MessageMarkdown = messageMarkdown;
             this.Priority = priority;
             this.PriorityName = priorityName;
             this.Rule = rule;
@@ -115,7 +121,13 @@
         public int? Line { get; }
 
         /// <inheritdoc/>
-        public string Message { get; }
+        public string MessageText { get; }
+
+        /// <inheritdoc/>
+        public string MessageHtml { get; }
+
+        /// <inheritdoc/>
+        public string MessageMarkdown { get; }
 
         /// <inheritdoc/>
         public int? Priority { get; }

--- a/src/Cake.Issues/IssueBuilder.cs
+++ b/src/Cake.Issues/IssueBuilder.cs
@@ -7,9 +7,11 @@
     /// </summary>
     public class IssueBuilder
     {
-        private readonly string message;
         private readonly string providerType;
         private readonly string providerName;
+        private readonly string messageText;
+        private string messageHtml;
+        private string messageMarkdown;
         private string projectFileRelativePath;
         private string projectName;
         private string filePath;
@@ -22,7 +24,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="IssueBuilder"/> class.
         /// </summary>
-        /// <param name="message">The message of the issue.</param>
+        /// <param name="message">The message of the issue in plain text format.</param>
         /// <param name="providerType">The type of the issue provider.</param>
         /// <param name="providerName">The human friendly name of the issue provider.</param>
         private IssueBuilder(
@@ -34,7 +36,7 @@
             providerType.NotNullOrWhiteSpace(nameof(providerType));
             providerName.NotNullOrWhiteSpace(nameof(providerName));
 
-            this.message = message;
+            this.messageText = message;
             this.providerType = providerType;
             this.providerName = providerName;
         }
@@ -42,7 +44,7 @@
         /// <summary>
         /// Initiates the creation of a new <see cref="IIssue"/>.
         /// </summary>
-        /// <param name="message">The message of the issue.</param>
+        /// <param name="message">The message of the issue in plain text format.</param>
         /// <param name="providerType">The type of the issue provider.</param>
         /// <param name="providerName">The human friendly name of the issue provider.</param>
         /// <returns>Builder class for creating a new issue.</returns>
@@ -62,7 +64,7 @@
         /// Initiates the creation of a new <see cref="IIssue"/>.
         /// </summary>
         /// <typeparam name="T">Type of the issue provider which has the issue created.</typeparam>
-        /// <param name="message">The message of the issue.</param>
+        /// <param name="message">The message of the issue in plain text format.</param>
         /// <param name="issueProvider">Issue provider which has the issue created.</param>
         /// <returns>Builder class for creating a new issue.</returns>
         public static IssueBuilder NewIssue<T>(
@@ -78,6 +80,32 @@
             message.NotNullOrWhiteSpace(nameof(message));
 
             return new IssueBuilder(message, typeof(T).FullName, issueProvider.ProviderName);
+        }
+
+        /// <summary>
+        /// Sets the message in HTML format.
+        /// </summary>
+        /// <param name="message">Message in HTML format.
+        /// Can be <c>null</c> or <see cref="string.Empty"/> if issue doesn't have a message in HTML format.</param>
+        /// <returns>Issue Builder instance.</returns>
+        public IssueBuilder WithMessageInHtmlFormat(string message)
+        {
+            this.messageHtml = message;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the message in Markdown format.
+        /// </summary>
+        /// <param name="message">Message in Markdown format.
+        /// Can be <c>null</c> or <see cref="string.Empty"/> if issue doesn't have a message in Markdown format.</param>
+        /// <returns>Issue Builder instance.</returns>
+        public IssueBuilder WithMessageInMarkdownFormat(string message)
+        {
+            this.messageMarkdown = message;
+
+            return this;
         }
 
         /// <summary>
@@ -224,7 +252,9 @@
                     this.projectName,
                     this.filePath,
                     this.line,
-                    this.message,
+                    this.messageText,
+                    this.messageHtml,
+                    this.messageMarkdown,
                     this.priority,
                     this.priorityName,
                     this.rule,

--- a/src/Cake.Issues/IssuesReader.cs
+++ b/src/Cake.Issues/IssuesReader.cs
@@ -40,9 +40,8 @@
         /// <summary>
         /// Read issues from issue providers.
         /// </summary>
-        /// <param name="format">Preferred format for comments.</param>
         /// <returns>List of issues.</returns>
-        public IEnumerable<IIssue> ReadIssues(IssueCommentFormat format)
+        public IEnumerable<IIssue> ReadIssues()
         {
             // Initialize issue providers and read issues.
             var issues = new List<IIssue>();
@@ -53,7 +52,7 @@
                 if (issueProvider.Initialize(this.settings))
                 {
                     this.log.Verbose("Reading issues from {0}...", providerName);
-                    var currentIssues = issueProvider.ReadIssues(format).ToList();
+                    var currentIssues = issueProvider.ReadIssues().ToList();
 
                     this.log.Verbose(
                         "Found {0} issues using issue provider {1}...",

--- a/src/Cake.Issues/ReadIssuesSettings.cs
+++ b/src/Cake.Issues/ReadIssuesSettings.cs
@@ -15,10 +15,5 @@
             : base(repositoryRoot)
         {
         }
-
-        /// <summary>
-        /// Gets or sets the preferred format in which issue comments should be returned.
-        /// </summary>
-        public IssueCommentFormat Format { get; set; } = IssueCommentFormat.Undefined;
     }
 }

--- a/src/Cake.Issues/Serialization/IssueDeserializationExtensions.cs
+++ b/src/Cake.Issues/Serialization/IssueDeserializationExtensions.cs
@@ -125,6 +125,8 @@
                 var version = (int)data["Version"];
                 switch (version)
                 {
+                    case 2:
+                        return JsonMapper.ToObject<SerializableIssueV2>(data.ToJson()).ToIssue();
                     default:
                         throw new Exception($"Not supported issue serialization format {version}");
                 }

--- a/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
+++ b/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
@@ -70,21 +70,23 @@
         }
 
         /// <summary>
-        /// Converts an <see cref="IIssue"/> to a <see cref="SerializableIssue"/>.
+        /// Converts an <see cref="IIssue"/> to a <see cref="SerializableIssueV2"/>.
         /// </summary>
         /// <param name="issue">Issue which should be converted.</param>
         /// <returns>Converted issue.</returns>
-        internal static SerializableIssue ToSerializableIssue(this IIssue issue)
+        internal static SerializableIssueV2 ToSerializableIssue(this IIssue issue)
         {
             issue.NotNull(nameof(issue));
 
-            return new SerializableIssue
+            return new SerializableIssueV2
             {
                 ProjectFileRelativePath = issue.ProjectFileRelativePath?.FullPath,
                 ProjectName = issue.ProjectName,
                 AffectedFileRelativePath = issue.AffectedFileRelativePath?.FullPath,
                 Line = issue.Line,
-                Message = issue.Message,
+                MessageText = issue.MessageText,
+                MessageMarkdown = issue.MessageMarkdown,
+                MessageHtml = issue.MessageHtml,
                 Priority = issue.Priority,
                 PriorityName = issue.PriorityName,
                 Rule = issue.Rule,

--- a/src/Cake.Issues/Serialization/SerializableIssueV2.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV2.cs
@@ -1,41 +1,75 @@
 ﻿namespace Cake.Issues.Serialization
 {
+    using System.Runtime.Serialization;
+
     /// <summary>
     /// Class for serializing and deserializing an <see cref="IIssue"/> instance.
     /// </summary>
-    internal class SerializableIssue
+    [DataContract]
+    internal class SerializableIssueV2
     {
+        /// <summary>
+        /// Gets the version of the serialization format.
+        /// </summary>
+        [DataMember]
+        public int Version
+        {
+            get
+            {
+                return 2;
+            }
+        }
+
         /// <inheritdoc cref="IIssue.ProjectFileRelativePath" />
+        [DataMember]
         public string ProjectFileRelativePath { get; set; }
 
         /// <inheritdoc cref="IIssue.ProjectName" />
+        [DataMember]
         public string ProjectName { get; set; }
 
         /// <inheritdoc cref="IIssue.AffectedFileRelativePath" />
+        [DataMember]
         public string AffectedFileRelativePath { get; set; }
 
         /// <inheritdoc cref="IIssue.Line" />
+        [DataMember]
         public int? Line { get; set; }
 
         /// <inheritdoc cref="IIssue.MessageText" />
-        public string Message { get; set; }
+        [DataMember]
+        public string MessageText { get; set; }
+
+        /// <inheritdoc cref="IIssue.MessageMarkdown" />
+        [DataMember]
+        public string MessageMarkdown { get; set; }
+
+        /// <inheritdoc cref="IIssue.MessageHtml" />
+        [DataMember]
+        public string MessageHtml { get; set; }
 
         /// <inheritdoc cref="IIssue.Priority" />
+        [DataMember]
         public int? Priority { get; set; }
 
         /// <inheritdoc cref="IIssue.PriorityName" />
+        [DataMember]
         public string PriorityName { get; set; }
 
         /// <inheritdoc cref="IIssue.Rule" />
+        [DataMember]
         public string Rule { get; set; }
 
         /// <inheritdoc cref="IIssue.RuleUrl" />
+        [DataMember]
         public string RuleUrl { get; set; }
 
         /// <inheritdoc cref="IIssue.ProviderType" />
+        [DataMember]
         public string ProviderType { get; set; }
 
         /// <inheritdoc cref="IIssue.ProviderName" />
+        [DataMember]
         public string ProviderName { get; set; }
     }
 }

--- a/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
@@ -3,16 +3,16 @@
     using System;
 
     /// <summary>
-    /// Extensions for <see cref="SerializableIssue"/>.
+    /// Extensions for <see cref="SerializableIssueV2"/>.
     /// </summary>
-    internal static class SerializableIssueExtensions
+    internal static class SerializableIssueV2Extensions
     {
         /// <summary>
-        /// Converts a <see cref="SerializableIssue"/> to an <see cref="Issue"/>.
+        /// Converts a <see cref="SerializableIssueV2"/> to an <see cref="Issue"/>.
         /// </summary>
         /// <param name="serializableIssue">Issue which should be converted.</param>
         /// <returns>Converted issue.</returns>
-        internal static Issue ToIssue(this SerializableIssue serializableIssue)
+        internal static Issue ToIssue(this SerializableIssueV2 serializableIssue)
         {
 #pragma warning disable SA1123 // Do not place regions within elements
             #region DupFinder Exclusion
@@ -31,9 +31,9 @@
                 serializableIssue.ProjectName,
                 serializableIssue.AffectedFileRelativePath,
                 serializableIssue.Line,
-                serializableIssue.Message,
-                null,
-                null,
+                serializableIssue.MessageText,
+                serializableIssue.MessageHtml,
+                serializableIssue.MessageMarkdown,
                 serializableIssue.Priority,
                 serializableIssue.PriorityName,
                 serializableIssue.Rule,


### PR DESCRIPTION
Supports messages in multiple format on issues. Instead of deciding in which format the message should be provided by the issue provider, `IIssue` contains now the message in all formats and the consumer can decide which of the formats fits the best.

Fixes #121 