### PR TITLE
(GH-159) Make IssueSerializationExtensions and IssueDeserializationExtensions public

### DIFF
--- a/src/Cake.Issues/Serialization/IssueDeserializationExtensions.cs
+++ b/src/Cake.Issues/Serialization/IssueDeserializationExtensions.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// Extensions for deserializing an <see cref="IIssue"/>.
     /// </summary>
-    internal static class IssueDeserializationExtensions
+    public static class IssueDeserializationExtensions
     {
         /// <summary>
         /// Deserializes an <see cref="Issue"/> from a JSON string.

--- a/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
+++ b/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Extensions for serializing an <see cref="IIssue"/> to the latest serialization format.
     /// </summary>
-    internal static class IssueSerializationExtensions
+    public static class IssueSerializationExtensions
     {
         /// <summary>
         /// Serializes an <see cref="IIssue"/> to a JSON string.


### PR DESCRIPTION
Make `IssueSerializationExtensions` and `IssueDeserializationExtensions` public so that they can be used in other addins basing on Cake.Issues

Fixes #159 