### PR TITLE
(GH-179) Add run information to IIssue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cs diff=csharp

--- a/src/Cake.Issues.Testing/IssueChecker.cs
+++ b/src/Cake.Issues.Testing/IssueChecker.cs
@@ -41,6 +41,7 @@
                 issueToCheck,
                 expectedIssue.ProviderType,
                 expectedIssue.ProviderName,
+                expectedIssue.Run,
                 expectedIssue.ProjectFileRelativePath?.ToString(),
                 expectedIssue.ProjectName,
                 expectedIssue.AffectedFileRelativePath?.ToString(),
@@ -61,6 +62,7 @@
         /// <param name="issue">Issue which should be checked.</param>
         /// <param name="providerType">Expected type of the issue provider.</param>
         /// <param name="providerName">Expected human friendly name of the issue provider.</param>
+        /// <param name="run">Expected name of the run which reported the issue.</param>
         /// <param name="projectFileRelativePath">Expected relative path of the project file.
         /// <c>null</c> if the issue is not expected to be related to a project.</param>
         /// <param name="projectName">Expected project name.
@@ -86,6 +88,7 @@
             IIssue issue,
             string providerType,
             string providerName,
+            string run,
             string projectFileRelativePath,
             string projectName,
             string affectedFileRelativePath,
@@ -111,6 +114,12 @@
             {
                 throw new Exception(
                     $"Expected issue.ProviderName to be '{providerName}' but was '{issue.ProviderName}'.");
+            }
+
+            if (issue.Run != run)
+            {
+                throw new Exception(
+                    $"Expected issue.Run to be '{run}' but was '{issue.Run}'.");
             }
 
             if (issue.ProjectFileRelativePath == null)

--- a/src/Cake.Issues.Tests/IIssueComparerTests.cs
+++ b/src/Cake.Issues.Tests/IIssueComparerTests.cs
@@ -358,6 +358,25 @@
             }
 
             [Fact]
+            public void Should_Return_False_If_Run_Is_Different()
+            {
+                // Given
+                var issue1 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run1")
+                        .Create();
+                var issue2 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run2")
+                        .Create();
+
+                // When / Then
+                CompareIssues(issue1, issue2, false);
+            }
+
+            [Fact]
             public void Should_Return_True_If_Same_Reference()
             {
                 // Given
@@ -712,6 +731,25 @@
             }
 
             [Fact]
+            public void Should_Return_True_If_Run_Is_Same()
+            {
+                // Given
+                var issue1 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run")
+                        .Create();
+                var issue2 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run")
+                        .Create();
+
+                // When / Then
+                CompareIssues(issue1, issue2, true);
+            }
+
+            [Fact]
             public void Should_Remove_Identical_Issues_From_List_Of_Issues()
             {
                 // Given
@@ -1009,6 +1047,25 @@
                 var issue2 =
                     IssueBuilder
                         .NewIssue("message", "providerType", "providerName2")
+                        .Create();
+
+                // When / Then
+                CompareIssues(issue1, issue2, false);
+            }
+
+            [Fact]
+            public void Should_Return_False_If_Run_Is_Different()
+            {
+                // Given
+                var issue1 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run1")
+                        .Create();
+                var issue2 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run2")
                         .Create();
 
                 // When / Then
@@ -1457,6 +1514,25 @@
                 var issue2 =
                     IssueBuilder
                         .NewIssue("message", "providerType", "providerName")
+                        .Create();
+
+                // When / Then
+                CompareIssues(issue1, issue2, true);
+            }
+
+            [Fact]
+            public void Should_Return_True_If_Run_Is_Same()
+            {
+                // Given
+                var issue1 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run")
+                        .Create();
+                var issue2 =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun("run")
                         .Create();
 
                 // When / Then

--- a/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
@@ -297,6 +297,7 @@
             [InlineData("{foo}", "{foo}")]
             [InlineData("foo {ProviderType} bar", "foo ProviderType Foo bar")]
             [InlineData("foo {ProviderName} bar", "foo ProviderName Foo bar")]
+            [InlineData("foo {Run} bar", "foo Run bar")]
             [InlineData("foo {Priority} bar", "foo 400 bar")]
             [InlineData("foo {PriorityName} bar", "foo Error bar")]
             [InlineData("foo {ProjectPath} bar", "foo src/Cake.Issues/Cake.Issues.csproj bar")]
@@ -318,6 +319,7 @@
                 var issue =
                     IssueBuilder
                         .NewIssue("MessageText Foo", "ProviderType Foo", "ProviderName Foo")
+                        .ForRun("Run")
                         .WithMessageInHtmlFormat("MessageHtml Foo")
                         .WithMessageInMarkdownFormat("MessageMarkdown Foo")
                         .InFile(@"src/Cake.Issues/foo.cs", 42, 23)

--- a/src/Cake.Issues.Tests/IssueBuilderTests.cs
+++ b/src/Cake.Issues.Tests/IssueBuilderTests.cs
@@ -988,5 +988,67 @@
                 issue.RuleUrl.ToString().ShouldBe(ruleUri);
             }
         }
+
+        public sealed class TheForRunMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Run_Is_Null()
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+                string run = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    fixture.IssueBuilder.ForRun(run));
+
+                // Then
+                result.IsArgumentNullException("run");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Run_Is_Empty()
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+                string run = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    fixture.IssueBuilder.ForRun(run));
+
+                // Then
+                result.IsArgumentException("run");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Run_Is_WhiteSpace()
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+                string run = " ";
+
+                // When
+                var result = Record.Exception(() =>
+                    fixture.IssueBuilder.ForRun(run));
+
+                // Then
+                result.IsArgumentException("run");
+            }
+
+            [Theory]
+            [InlineData("run")]
+            public void Should_Set_Run(string run)
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+
+                // When
+                var issue = fixture.IssueBuilder.ForRun(run).Create();
+
+                // Then
+                issue.Run.ToString().ShouldBe(run);
+            }
+        }
     }
 }

--- a/src/Cake.Issues.Tests/IssueReaderTests.cs
+++ b/src/Cake.Issues.Tests/IssueReaderTests.cs
@@ -288,6 +288,49 @@
                 issues.ShouldContain(issue3);
                 issues.ShouldContain(issue4);
             }
+
+            [Fact]
+            public void Should_Set_Run_Property()
+            {
+                // Given
+                var issue1 =
+                    IssueBuilder
+                        .NewIssue("Foo", "ProviderTypeFoo", "ProviderNameFoo")
+                        .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 10)
+                        .OfRule("Foo")
+                        .WithPriority(IssuePriority.Warning)
+                        .Create();
+                var issue2 =
+                    IssueBuilder
+                        .NewIssue("Bar", "ProviderTypeBar", "ProviderNameBar")
+                        .InFile(@"src\Cake.Issues.Tests\FakeIssueProvider.cs", 12)
+                        .OfRule("Bar")
+                        .WithPriority(IssuePriority.Warning)
+                        .Create();
+                var fixture = new IssuesFixture();
+                fixture.IssueProviders.Clear();
+                fixture.IssueProviders.Add(
+                    new FakeIssueProvider(
+                        fixture.Log,
+                        new List<IIssue>
+                        {
+                            issue1,
+                            issue2,
+                        }));
+                var run = "Run";
+                fixture.Settings.Run = run;
+
+                // When
+                var issues = fixture.ReadIssues().ToList();
+
+                // Then
+                issues.Count.ShouldBe(2);
+                issues.ShouldContain(issue1);
+                issue1.Run.ShouldBe(run);
+                issues.ShouldContain(issue2);
+                issue2.Run.ShouldBe(run);
+            }
+
         }
     }
 }

--- a/src/Cake.Issues.Tests/IssueTests.cs
+++ b/src/Cake.Issues.Tests/IssueTests.cs
@@ -29,6 +29,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -45,6 +46,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -72,6 +74,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -88,6 +91,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -113,6 +117,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -129,6 +134,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -154,6 +160,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -170,6 +177,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -195,6 +203,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -211,6 +220,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -236,6 +246,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -252,6 +263,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -280,6 +292,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -296,6 +309,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -321,6 +335,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -337,6 +352,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -362,6 +378,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -378,6 +395,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -403,6 +421,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -419,6 +438,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -447,6 +467,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -463,6 +484,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -490,6 +512,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -506,6 +529,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -531,6 +555,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -547,6 +572,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -572,6 +598,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -588,6 +615,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -613,6 +641,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -629,6 +658,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -662,6 +692,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -678,6 +709,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -707,6 +739,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -723,6 +756,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -748,6 +782,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -764,6 +799,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -789,6 +825,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -805,6 +842,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -830,6 +868,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -846,6 +885,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -872,6 +912,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -888,6 +929,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -916,6 +958,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -932,6 +975,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -957,6 +1001,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -973,6 +1018,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -998,6 +1044,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1014,6 +1061,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1041,6 +1089,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1057,6 +1106,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1085,6 +1135,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1101,6 +1152,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1126,6 +1178,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1142,6 +1195,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1167,6 +1221,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1183,6 +1238,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1208,6 +1264,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1224,6 +1281,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1255,6 +1313,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1271,6 +1330,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1302,6 +1362,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1318,6 +1379,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1351,6 +1413,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1367,6 +1430,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1395,6 +1459,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1411,6 +1476,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1436,6 +1502,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1452,6 +1519,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1477,6 +1545,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1493,6 +1562,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1518,6 +1588,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1534,6 +1605,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1564,6 +1636,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1580,6 +1653,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1608,6 +1682,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1624,6 +1699,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1649,6 +1725,7 @@
                     Uri ruleUri = null;
                     var providerType = "ProviderType";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1665,11 +1742,60 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
                     // Then
                     issue.RuleUrl.ShouldBe(ruleUri);
+                }
+            }
+
+            public sealed class TheRunArgument
+            {
+                [Theory]
+                [InlineData(null)]
+                [InlineData("")]
+                [InlineData("run")]
+                public void Should_Set_Run(string run)
+                {
+                    // Given
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var column = 50;
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+
+                    // When
+                    var issue =
+                        new Issue(
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            column,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            run,
+                            providerType,
+                            providerName);
+
+                    // Then
+                    issue.Run.ShouldBe(run);
                 }
             }
 
@@ -1693,6 +1819,7 @@
                     var ruleUri = new Uri("https://google.com");
                     string providerType = null;
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1709,6 +1836,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1734,6 +1862,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = string.Empty;
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1750,6 +1879,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1775,6 +1905,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = " ";
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1791,6 +1922,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1816,6 +1948,7 @@
                     var rule = "Rule";
                     var ruleUri = new Uri("https://google.com");
                     var providerName = "ProviderName";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1832,6 +1965,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 
@@ -1860,6 +1994,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     string providerName = null;
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1876,6 +2011,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1901,6 +2037,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = string.Empty;
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1917,6 +2054,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1942,6 +2080,7 @@
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
                     var providerName = " ";
+                    var run = "Run";
 
                     // When
                     var result = Record.Exception(() =>
@@ -1958,6 +2097,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName));
 
@@ -1983,6 +2123,7 @@
                     var rule = "Rule";
                     var ruleUri = new Uri("https://google.com");
                     var providerType = "ProviderType";
+                    var run = "Run";
 
                     // When
                     var issue =
@@ -1999,6 +2140,7 @@
                             priorityName,
                             rule,
                             ruleUri,
+                            run,
                             providerType,
                             providerName);
 

--- a/src/Cake.Issues.Tests/IssuesFixture.cs
+++ b/src/Cake.Issues.Tests/IssuesFixture.cs
@@ -20,7 +20,7 @@
 
         public IList<FakeIssueProvider> IssueProviders { get; set; }
 
-        public RepositorySettings Settings { get; set; }
+        public ReadIssuesSettings Settings { get; set; }
 
         public IEnumerable<IIssue> ReadIssues()
         {

--- a/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
@@ -145,6 +145,7 @@
                         "Something went wrong.",
                         "TestProvider",
                         "Test Provider")
+                        .ForRun("TestRun")
                         .WithMessageInHtmlFormat("Something went <b>wrong</b>.")
                         .WithMessageInMarkdownFormat("Something went **wrong**.")
                         .InProject(@"src\Foo\Bar.csproj", "Bar")

--- a/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
@@ -114,6 +114,24 @@
             }
 
             [Fact]
+            public void Should_Give_Correct_Result_For_Run_After_Roundtrip()
+            {
+                // Given
+                var run = "run";
+                var issue =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun(run)
+                        .Create();
+
+                // When
+                var result = issue.SerializeToJsonString().DeserializeToIssue();
+
+                // Then
+                result.Run.ShouldBe(run);
+            }
+
+            [Fact]
             public void Should_Give_Correct_Result_For_ProjectFileRelativePath_After_Roundtrip()
             {
                 // Given
@@ -423,6 +441,34 @@
                 result.Count().ShouldBe(2);
                 result.First().ProviderName.ShouldBe(providerName1);
                 result.Last().ProviderName.ShouldBe(providerName2);
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_Run_After_Roundtrip()
+            {
+                // Given
+                var run1 = "run1";
+                var run2 = "run2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue("message1", "providerType1", "providerName1")
+                            .ForRun(run1)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("message2", "providerType2", "providerName2")
+                            .ForRun(run2)
+                            .Create(),
+                    };
+
+                // When
+                var result = issues.SerializeToJsonString().DeserializeToIssues();
+
+                // Then
+                result.Count().ShouldBe(2);
+                result.First().Run.ShouldBe(run1);
+                result.Last().Run.ShouldBe(run2);
             }
 
             [Fact]
@@ -848,6 +894,36 @@
 
                     // Then
                     result.ProviderName.ShouldBe(providerName);
+                }
+                finally
+                {
+                    if (System.IO.File.Exists(filePath.FullPath))
+                    {
+                        System.IO.File.Delete(filePath.FullPath);
+                    }
+                }
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_Run_After_Roundtrip()
+            {
+                // Given
+                var run = "run";
+                var issue =
+                    IssueBuilder
+                        .NewIssue("message", "providerType", "providerName")
+                        .ForRun(run)
+                        .Create();
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issue.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssue();
+
+                    // Then
+                    result.Run.ShouldBe(run);
                 }
                 finally
                 {
@@ -1343,6 +1419,46 @@
                     result.Count().ShouldBe(2);
                     result.First().ProviderName.ShouldBe(providerName1);
                     result.Last().ProviderName.ShouldBe(providerName2);
+                }
+                finally
+                {
+                    if (System.IO.File.Exists(filePath.FullPath))
+                    {
+                        System.IO.File.Delete(filePath.FullPath);
+                    }
+                }
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_Run_After_Roundtrip()
+            {
+                // Given
+                var run1 = "run1";
+                var run2 = "run2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue("message1", "providerType1", "providerName1")
+                            .ForRun(run1)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("message2", "providerType2", "providerName2")
+                            .ForRun(run2)
+                            .Create(),
+                    };
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issues.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssues();
+
+                    // Then
+                    result.Count().ShouldBe(2);
+                    result.First().Run.ShouldBe(run1);
+                    result.Last().Run.ShouldBe(run2);
                 }
                 finally
                 {

--- a/src/Cake.Issues.Tests/Testfiles/issueV3.json
+++ b/src/Cake.Issues.Tests/Testfiles/issueV3.json
@@ -12,6 +12,7 @@
   "ProjectName": "Bar",
   "ProviderName": "Test Provider",
   "ProviderType": "TestProvider",
+  "Run":  "TestRun",
   "Rule": "Rule",
   "RuleUrl": "https://google.com"
 }

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
@@ -14,6 +14,7 @@
         {
             this.ProviderType = providerType;
             this.ProviderName = providerName;
+            this.Run = "Test Run";
             this.ProjectFileRelativePath = @"src\project.file";
             this.ProjectName = "ProjectName";
             this.AffectedFileRelativePath = @"src\source.file";
@@ -28,6 +29,7 @@
             this.RuleUrl = new Uri("https://google.com");
 
             this.IssueBuilder
+                .ForRun(this.Run)
                 .WithMessageInHtmlFormat(this.MessageHtml)
                 .WithMessageInMarkdownFormat(this.MessageMarkdown)
                 .InProject(this.ProjectFileRelativePath, this.ProjectName)
@@ -44,6 +46,8 @@
         public string ProviderType { get; private set; }
 
         public string ProviderName { get; private set; }
+
+        public string Run { get; private set; }
 
         public string ProjectFileRelativePath { get; private set; }
 

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
@@ -144,6 +144,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -172,6 +173,7 @@
                     fixture.Issue,
                     fixture.ProviderType,
                     fixture.ProviderName,
+                    fixture.Run,
                     fixture.ProjectFileRelativePath,
                     fixture.ProjectName,
                     fixture.AffectedFileRelativePath,
@@ -204,6 +206,7 @@
                         fixture.Issue,
                         expectedValue,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -238,6 +241,7 @@
                         fixture.Issue,
                         fixture.ProviderType,
                         expectedValue,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -257,6 +261,45 @@
             }
 
             [Theory]
+            [InlineData("Run", "Foo")]
+            [InlineData(null, "Foo")]
+            [InlineData("", "Foo")]
+            [InlineData(" ", "Foo")]
+            public void Should_Throw_If_Run_Is_Different(string expectedValue, string actualValue)
+            {
+                // Given
+                var fixture = new IssueCheckerFixture();
+                var issue =
+                    fixture.IssueBuilder
+                        .ForRun(actualValue)
+                        .Create();
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueChecker.Check(
+                        fixture.Issue,
+                        fixture.ProviderType,
+                        fixture.ProviderName,
+                        expectedValue,
+                        fixture.ProjectFileRelativePath,
+                        fixture.ProjectName,
+                        fixture.AffectedFileRelativePath,
+                        fixture.Line,
+                        fixture.Column,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
+                        fixture.Priority,
+                        fixture.PriorityName,
+                        fixture.Rule,
+                        fixture.RuleUrl));
+
+                // Then
+                result.ShouldBeOfType<Exception>();
+                result.Message.ShouldStartWith("Expected issue.Run");
+            }
+
+            [Theory]
             [InlineData(@"src\project.file", @"src\foo")]
             public void Should_Throw_If_ProjectFileRelativePath_Is_Different(string expectedValue, string actualValue)
             {
@@ -273,6 +316,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         expectedValue,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -311,6 +355,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         expectedValue,
                         fixture.AffectedFileRelativePath,
@@ -346,6 +391,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         expectedValue,
@@ -383,6 +429,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -420,6 +467,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -454,6 +502,7 @@
                         fixture.Issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -492,6 +541,7 @@
                         fixture.Issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -530,6 +580,7 @@
                         fixture.Issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -565,6 +616,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -603,6 +655,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -641,6 +694,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -676,6 +730,7 @@
                         issue,
                         fixture.ProviderType,
                         fixture.ProviderName,
+                        fixture.Run,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,

--- a/src/Cake.Issues/IIssue.cs
+++ b/src/Cake.Issues/IIssue.cs
@@ -80,10 +80,10 @@
         Uri RuleUrl { get; }
 
         /// <summary>
-        /// Gets the description of the run.
+        /// Gets or sets the description of the run.
         /// Can be <c>null</c> or <see cref="string.Empty"/> if no run information is provided.
         /// </summary>
-        string Run { get; }
+        string Run { get; set; }
 
         /// <summary>
         /// Gets the type of the issue provider.

--- a/src/Cake.Issues/IIssue.cs
+++ b/src/Cake.Issues/IIssue.cs
@@ -80,6 +80,12 @@
         Uri RuleUrl { get; }
 
         /// <summary>
+        /// Gets the description of the run.
+        /// Can be <c>null</c> or <see cref="string.Empty"/> if no run information is provided.
+        /// </summary>
+        string Run { get; }
+
+        /// <summary>
         /// Gets the type of the issue provider.
         /// </summary>
         string ProviderType { get; }

--- a/src/Cake.Issues/IIssueComparer.cs
+++ b/src/Cake.Issues/IIssueComparer.cs
@@ -74,6 +74,7 @@
                 (x.PriorityName == y.PriorityName) &&
                 (x.Rule == y.Rule) &&
                 (x.RuleUrl?.ToString() == y.RuleUrl?.ToString()) &&
+                (x.Run == y.Run) &&
                 (x.ProviderType == y.ProviderType) &&
                 (x.ProviderName == y.ProviderName);
         }
@@ -98,6 +99,7 @@
                         obj.PriorityName,
                         obj.Rule,
                         obj.RuleUrl,
+                        obj.Run,
                         obj.ProviderType,
                         obj.ProviderName);
             }
@@ -117,6 +119,7 @@
                         obj.PriorityName,
                         obj.Rule,
                         obj.RuleUrl,
+                        obj.Run,
                         obj.ProviderType,
                         obj.ProviderName);
             }

--- a/src/Cake.Issues/IIssueExtensions.cs
+++ b/src/Cake.Issues/IIssueExtensions.cs
@@ -156,6 +156,10 @@
         ///         <description>The value of <see cref="IIssue.RuleUrl"/>.</description>
         ///     </item>
         ///     <item>
+        ///         <term>{Run}</term>
+        ///         <description>The value of <see cref="IIssue.Run"/>.</description>
+        ///     </item>
+        ///     <item>
         ///         <term>{MessageText}</term>
         ///         <description>The value of <see cref="IIssue.MessageText"/>.</description>
         ///     </item>
@@ -194,6 +198,7 @@
                     .Replace("{Column}", issue.Column?.ToString())
                     .Replace("{Rule}", issue.Rule)
                     .Replace("{RuleUrl}", issue.RuleUrl?.ToString())
+                    .Replace("{Run}", issue.Run)
                     .Replace("{MessageText}", issue.Message(IssueCommentFormat.PlainText))
                     .Replace("{MessageHtml}", issue.Message(IssueCommentFormat.Html))
                     .Replace("{MessageMarkdown}", issue.Message(IssueCommentFormat.Markdown));

--- a/src/Cake.Issues/Issue.cs
+++ b/src/Cake.Issues/Issue.cs
@@ -34,6 +34,7 @@
         /// <c>null</c> or <see cref="string.Empty"/> if issue has no specific rule ID.</param>
         /// <param name="ruleUrl">The URL containing information about the failing rule.
         /// <c>null</c> if no URL is available.</param>
+        /// <param name="run">Gets the description of the run.</param>
         /// <param name="providerType">The type of the issue provider.</param>
         /// <param name="providerName">The human friendly name of the issue provider.</param>
         public Issue(
@@ -49,6 +50,7 @@
             string priorityName,
             string rule,
             Uri ruleUrl,
+            string run,
             string providerType,
             string providerName)
         {
@@ -114,6 +116,7 @@
             this.PriorityName = priorityName;
             this.Rule = rule;
             this.RuleUrl = ruleUrl;
+            this.Run = run;
             this.ProviderType = providerType;
             this.ProviderName = providerName;
         }
@@ -153,6 +156,9 @@
 
         /// <inheritdoc/>
         public Uri RuleUrl { get; }
+
+        /// <inheritdoc/>
+        public string Run { get; }
 
         /// <inheritdoc/>
         public string ProviderType { get; }

--- a/src/Cake.Issues/Issue.cs
+++ b/src/Cake.Issues/Issue.cs
@@ -158,7 +158,7 @@
         public Uri RuleUrl { get; }
 
         /// <inheritdoc/>
-        public string Run { get; }
+        public string Run { get; set; }
 
         /// <inheritdoc/>
         public string ProviderType { get; }

--- a/src/Cake.Issues/IssueBuilder.cs
+++ b/src/Cake.Issues/IssueBuilder.cs
@@ -21,6 +21,7 @@
         private string priorityName;
         private string rule;
         private Uri ruleUrl;
+        private string run;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IssueBuilder"/> class.
@@ -265,6 +266,20 @@
         }
 
         /// <summary>
+        /// Sets the name of the run where the issue was reported.
+        /// </summary>
+        /// <param name="run">The name of the run where the issue was reported.</param>
+        /// <returns>Issue Builder instance.</returns>
+        public IssueBuilder ForRun(string run)
+        {
+            run.NotNullOrWhiteSpace(nameof(run));
+
+            this.run = run;
+
+            return this;
+        }
+
+        /// <summary>
         /// Creates a new <see cref="IIssue"/>.
         /// </summary>
         /// <returns>New issue object.</returns>
@@ -284,6 +299,7 @@
                     this.priorityName,
                     this.rule,
                     this.ruleUrl,
+                    this.run,
                     this.providerType,
                     this.providerName);
         }

--- a/src/Cake.Issues/IssuesReader.cs
+++ b/src/Cake.Issues/IssuesReader.cs
@@ -11,7 +11,7 @@
     {
         private readonly ICakeLog log;
         private readonly List<IIssueProvider> issueProviders = new List<IIssueProvider>();
-        private readonly RepositorySettings settings;
+        private readonly ReadIssuesSettings settings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IssuesReader"/> class.
@@ -22,7 +22,7 @@
         public IssuesReader(
             ICakeLog log,
             IEnumerable<IIssueProvider> issueProviders,
-            RepositorySettings settings)
+            ReadIssuesSettings settings)
         {
             log.NotNull(nameof(log));
             settings.NotNull(nameof(settings));
@@ -58,6 +58,8 @@
                         "Found {0} issues using issue provider {1}...",
                         currentIssues.Count,
                         providerName);
+
+                    currentIssues.ForEach(x => x.Run = this.settings.Run);
 
                     issues.AddRange(currentIssues);
                 }

--- a/src/Cake.Issues/ReadIssuesSettings.cs
+++ b/src/Cake.Issues/ReadIssuesSettings.cs
@@ -15,5 +15,10 @@
             : base(repositoryRoot)
         {
         }
+
+        /// <summary>
+        /// Gets or sets the name of the run.
+        /// </summary>
+        public string Run { get; set; }
     }
 }

--- a/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
+++ b/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
@@ -92,6 +92,7 @@
                 PriorityName = issue.PriorityName,
                 Rule = issue.Rule,
                 RuleUrl = issue.RuleUrl?.ToString(),
+                Run = issue.Run,
                 ProviderType = issue.ProviderType,
                 ProviderName = issue.ProviderName,
             };

--- a/src/Cake.Issues/Serialization/SerializableIssueExtensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueExtensions.cs
@@ -39,6 +39,7 @@
                 serializableIssue.PriorityName,
                 serializableIssue.Rule,
                 ruleUrl,
+                null,
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName);
 

--- a/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
@@ -39,6 +39,7 @@
                 serializableIssue.PriorityName,
                 serializableIssue.Rule,
                 ruleUrl,
+                null,
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName);
 

--- a/src/Cake.Issues/Serialization/SerializableIssueV3.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV3.cs
@@ -75,5 +75,9 @@
         /// <inheritdoc cref="IIssue.ProviderName" />
         [DataMember]
         public string ProviderName { get; set; }
+
+        /// <inheritdoc cref="IIssue.Run" />
+        [DataMember]
+        public string Run { get; set; }
     }
 }

--- a/src/Cake.Issues/Serialization/SerializableIssueV3Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV3Extensions.cs
@@ -39,6 +39,7 @@
                 serializableIssue.PriorityName,
                 serializableIssue.Rule,
                 ruleUrl,
+                serializableIssue.Run,
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName);
 


### PR DESCRIPTION
Add run information to `IIssue` to allow differentiating between issues from different runs by the same issue provider.

Run information can be passed to the `ReadIssues` alias through the `ReadIssuesSettings`.

Fixes #179 