### PR TITLE
(GH-170) Add identifier to `IIssue`

### DIFF
--- a/src/Cake.Issues.Testing/IssueChecker.cs
+++ b/src/Cake.Issues.Testing/IssueChecker.cs
@@ -42,6 +42,7 @@
                 expectedIssue.ProviderType,
                 expectedIssue.ProviderName,
                 expectedIssue.Run,
+                expectedIssue.Identifier,
                 expectedIssue.ProjectFileRelativePath?.ToString(),
                 expectedIssue.ProjectName,
                 expectedIssue.AffectedFileRelativePath?.ToString(),
@@ -63,6 +64,7 @@
         /// <param name="providerType">Expected type of the issue provider.</param>
         /// <param name="providerName">Expected human friendly name of the issue provider.</param>
         /// <param name="run">Expected name of the run which reported the issue.</param>
+        /// <param name="identifier">Expected identifier of the issue.</param>
         /// <param name="projectFileRelativePath">Expected relative path of the project file.
         /// <c>null</c> if the issue is not expected to be related to a project.</param>
         /// <param name="projectName">Expected project name.
@@ -89,6 +91,7 @@
             string providerType,
             string providerName,
             string run,
+            string identifier,
             string projectFileRelativePath,
             string projectName,
             string affectedFileRelativePath,
@@ -120,6 +123,12 @@
             {
                 throw new Exception(
                     $"Expected issue.Run to be '{run}' but was '{issue.Run}'.");
+            }
+
+            if (issue.Identifier != identifier)
+            {
+                throw new Exception(
+                    $"Expected issue.Identifier to be '{identifier}' but was '{issue.Identifier}'.");
             }
 
             if (issue.ProjectFileRelativePath == null)

--- a/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
@@ -298,6 +298,7 @@
             [InlineData("foo {ProviderType} bar", "foo ProviderType Foo bar")]
             [InlineData("foo {ProviderName} bar", "foo ProviderName Foo bar")]
             [InlineData("foo {Run} bar", "foo Run bar")]
+            [InlineData("foo {Identifier} bar", "foo Identifier Foo bar")]
             [InlineData("foo {Priority} bar", "foo 400 bar")]
             [InlineData("foo {PriorityName} bar", "foo Error bar")]
             [InlineData("foo {ProjectPath} bar", "foo src/Cake.Issues/Cake.Issues.csproj bar")]
@@ -318,7 +319,7 @@
                 // Given
                 var issue =
                     IssueBuilder
-                        .NewIssue("MessageText Foo", "ProviderType Foo", "ProviderName Foo")
+                        .NewIssue("Identifier Foo", "MessageText Foo", "ProviderType Foo", "ProviderName Foo")
                         .ForRun("Run")
                         .WithMessageInHtmlFormat("MessageHtml Foo")
                         .WithMessageInMarkdownFormat("MessageMarkdown Foo")

--- a/src/Cake.Issues.Tests/IssueBuilderFixture.cs
+++ b/src/Cake.Issues.Tests/IssueBuilderFixture.cs
@@ -3,14 +3,14 @@
     internal class IssueBuilderFixture
     {
         public IssueBuilderFixture()
-            : this("Message", "ProviderType", "ProviderName")
+            : this("Identifier", "Message", "ProviderType", "ProviderName")
         {
         }
 
-        public IssueBuilderFixture(string messageText, string providerType, string providerName)
+        public IssueBuilderFixture(string identifier, string messageText, string providerType, string providerName)
         {
             this.IssueBuilder =
-                IssueBuilder.NewIssue(messageText, providerType, providerName);
+                IssueBuilder.NewIssue(identifier, messageText, providerType, providerName);
         }
 
         public IssueBuilder IssueBuilder { get; private set; }

--- a/src/Cake.Issues.Tests/IssueBuilderTests.cs
+++ b/src/Cake.Issues.Tests/IssueBuilderTests.cs
@@ -8,7 +8,7 @@
 
     public sealed class IssueBuilderTests
     {
-        public sealed class TheNewIssueMethod
+        public sealed class TheNewIssueMethodWithMessageAsIdentifier
         {
             [Fact]
             public void Should_Throw_If_Message_Is_Null()
@@ -153,9 +153,364 @@
                 // Then
                 result.IsArgumentOutOfRangeException("providerName");
             }
+
+            [Fact]
+            public void Should_Set_Identifier()
+            {
+                // Given
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.Identifier.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Set_Message()
+            {
+                // Given
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.MessageText.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderType()
+            {
+                // Given
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.ProviderType.ShouldBe(providerType);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderName()
+            {
+                // Given
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.ProviderName.ShouldBe(providerName);
+            }
         }
 
-        public sealed class TheNewIssueOfTMethod
+        public sealed class TheNewIssueMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Identifier_Is_Null()
+            {
+                // Given
+                string identifier = null;
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentNullException("identifier");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Identifier_Is_Empty()
+            {
+                // Given
+                var identifier = string.Empty;
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("identifier");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Identifier_Is_WhiteSpace()
+            {
+                // Given
+                var identifier = " ";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("identifier");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Message_Is_Null()
+            {
+                // Given
+                var identifier = "Identifier";
+                string message = null;
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentNullException("message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Message_Is_Empty()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = string.Empty;
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Message_Is_WhiteSpace()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = " ";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProviderType_Is_Null()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                string providerType = null;
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentNullException("providerType");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProviderType_Is_Empty()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = string.Empty;
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("providerType");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProviderType_Is_WhiteSpace()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = " ";
+                var providerName = "ProviderName";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("providerType");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProviderName_Is_Null()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                string providerName = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentNullException("providerName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProviderName_Is_Empty()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("providerName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_ProviderName_Is_WhiteSpace()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = " ";
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, providerType, providerName));
+
+                // Then
+                result.IsArgumentOutOfRangeException("providerName");
+            }
+
+            [Fact]
+            public void Should_Set_Identifier()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.Identifier.ShouldBe(identifier);
+            }
+
+            [Fact]
+            public void Should_Set_Message()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.MessageText.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderType()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.ProviderType.ShouldBe(providerType);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderName()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var providerType = "ProviderType";
+                var providerName = "ProviderName";
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, providerType, providerName)
+                        .Create();
+
+                // Then
+                result.ProviderName.ShouldBe(providerName);
+            }
+        }
+
+        public sealed class TheNewIssueOfTMethodWithMessageAsIdentifier
         {
             [Fact]
             public void Should_Throw_If_Message_Is_Null()
@@ -215,6 +570,261 @@
 
                 // Then
                 result.IsArgumentNullException("issueProvider");
+            }
+
+            [Fact]
+            public void Should_Set_Identifier()
+            {
+                // Given
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, issueProvider)
+                        .Create();
+
+                // Then
+                result.Identifier.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Set_Message()
+            {
+                // Given
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, issueProvider)
+                        .Create();
+
+                // Then
+                result.MessageText.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderType()
+            {
+                // Given
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, issueProvider)
+                        .Create();
+
+                // Then
+                result.ProviderType.ShouldBe(issueProvider.GetType().FullName);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderName()
+            {
+                // Given
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(message, issueProvider)
+                        .Create();
+
+                // Then
+                result.ProviderName.ShouldBe(issueProvider.ProviderName);
+            }
+        }
+
+        public sealed class TheNewIssueOfTMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Identifier_Is_Null()
+            {
+                // Given
+                string identifier = null;
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentNullException("identifier");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Identifier_Is_Empty()
+            {
+                // Given
+                var identifier = string.Empty;
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentOutOfRangeException("identifier");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Identifier_Is_WhiteSpace()
+            {
+                // Given
+                var identifier = " ";
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentOutOfRangeException("identifier");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Message_Is_Null()
+            {
+                // Given
+                var identifier = "Identifier";
+                string message = null;
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentNullException("message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Message_Is_Empty()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = string.Empty;
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentOutOfRangeException("message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Message_Is_WhiteSpace()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = " ";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentOutOfRangeException("message");
+            }
+
+            [Fact]
+            public void Should_Throw_If_IssueProvider_Is_Null()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                IIssueProvider issueProvider = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueBuilder.NewIssue(identifier, message, issueProvider));
+
+                // Then
+                result.IsArgumentNullException("issueProvider");
+            }
+
+            [Fact]
+            public void Should_Set_Identifier()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, issueProvider)
+                        .Create();
+
+                // Then
+                result.Identifier.ShouldBe(identifier);
+            }
+
+            [Fact]
+            public void Should_Set_Message()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, issueProvider)
+                        .Create();
+
+                // Then
+                result.MessageText.ShouldBe(message);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderType()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, issueProvider)
+                        .Create();
+
+                // Then
+                result.ProviderType.ShouldBe(issueProvider.GetType().FullName);
+            }
+
+            [Fact]
+            public void Should_Set_ProviderName()
+            {
+                // Given
+                var identifier = "Identifier";
+                var message = "Message";
+                var issueProvider = new FakeIssueProvider(new FakeLog());
+
+                // When
+                var result =
+                    IssueBuilder
+                        .NewIssue(identifier, message, issueProvider)
+                        .Create();
+
+                // Then
+                result.ProviderName.ShouldBe(issueProvider.ProviderName);
             }
         }
 

--- a/src/Cake.Issues.Tests/IssueReaderTests.cs
+++ b/src/Cake.Issues.Tests/IssueReaderTests.cs
@@ -330,7 +330,6 @@
                 issues.ShouldContain(issue2);
                 issue2.Run.ShouldBe(run);
             }
-
         }
     }
 }

--- a/src/Cake.Issues.Tests/IssueTests.cs
+++ b/src/Cake.Issues.Tests/IssueTests.cs
@@ -9,6 +9,189 @@
     {
         public sealed class TheCtor
         {
+            public sealed class TheIdentifierArgument
+            {
+                [Fact]
+                public void Should_Throw_If_Identifier_Is_Null()
+                {
+                    // Given
+                    string identifier = null;
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var column = 50;
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+                    var run = "Run";
+
+                    // When
+                    var result = Record.Exception(() =>
+                        new Issue(
+                            identifier,
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            column,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            run,
+                            providerType,
+                            providerName));
+
+                    // Then
+                    result.IsArgumentNullException("identifier");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Identifier_Is_Empty()
+                {
+                    // Given
+                    var identifier = string.Empty;
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var column = 50;
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+                    var run = "Run";
+
+                    // When
+                    var result = Record.Exception(() =>
+                        new Issue(
+                            identifier,
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            column,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            run,
+                            providerType,
+                            providerName));
+
+                    // Then
+                    result.IsArgumentOutOfRangeException("identifier");
+                }
+
+                [Fact]
+                public void Should_Throw_If_Identifier_Is_WhiteSpace()
+                {
+                    // Given
+                    var identifier = " ";
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var column = 50;
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+                    var run = "Run";
+
+                    // When
+                    var result = Record.Exception(() =>
+                        new Issue(
+                            identifier,
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            column,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            run,
+                            providerType,
+                            providerName));
+
+                    // Then
+                    result.IsArgumentOutOfRangeException("identifier");
+                }
+
+                [Theory]
+                [InlineData("identifier")]
+                public void Should_Set_Identifier(string identifier)
+                {
+                    // Given
+                    var projectPath = @"src\foo.csproj";
+                    var projectName = "foo";
+                    var filePath = @"src\foo.cs";
+                    var line = 10;
+                    var column = 50;
+                    var messageText = "MessageText";
+                    var messageHtml = "MessageHtml";
+                    var messageMarkdown = "MessageMarkdown";
+                    var priority = 1;
+                    var priorityName = "Warning";
+                    var rule = "Rule";
+                    var ruleUri = new Uri("https://google.com");
+                    var providerType = "ProviderType";
+                    var providerName = "ProviderName";
+                    var run = "Run";
+
+                    // When
+                    var issue =
+                        new Issue(
+                            identifier,
+                            projectPath,
+                            projectName,
+                            filePath,
+                            line,
+                            column,
+                            messageText,
+                            messageHtml,
+                            messageMarkdown,
+                            priority,
+                            priorityName,
+                            rule,
+                            ruleUri,
+                            run,
+                            providerType,
+                            providerName);
+
+                    // Then
+                    issue.Identifier.ShouldBe(identifier);
+                }
+            }
+
             public sealed class TheProjectFileRelativePathArgument
             {
                 [Theory]
@@ -16,6 +199,7 @@
                 public void Should_Throw_If_Project_Path_Is_Invalid(string projectPath)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 100;
@@ -34,6 +218,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -61,6 +246,7 @@
                 public void Should_Throw_If_File_Path_Is_Absolute(string projectPath)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 100;
@@ -79,6 +265,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -103,6 +290,7 @@
                 public void Should_Handle_Project_Paths_Which_Are_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     string projectPath = null;
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -122,6 +310,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -146,6 +335,7 @@
                 public void Should_Handle_Project_Paths_Which_Are_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = string.Empty;
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -165,6 +355,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -189,6 +380,7 @@
                 public void Should_Handle_Project_Paths_Which_Are_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = " ";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -208,6 +400,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -233,6 +426,7 @@
                 public void Should_Set_ProjectFileRelativePath(string projectPath)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
                     var line = 10;
@@ -251,6 +445,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -278,6 +473,7 @@
                 public void Should_Handle_Projects_Which_Are_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     string projectName = null;
                     var filePath = @"src\foo.cs";
@@ -297,6 +493,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -321,6 +518,7 @@
                 public void Should_Handle_Projects_Which_Are_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = string.Empty;
                     var filePath = @"src\foo.cs";
@@ -340,6 +538,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -364,6 +563,7 @@
                 public void Should_Handle_Projects_Which_Are_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = " ";
                     var filePath = @"src\foo.cs";
@@ -383,6 +583,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -408,6 +609,7 @@
                 public void Should_Set_ProjectName(string projectName)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var filePath = @"src\foo.cs";
                     var line = 10;
@@ -426,6 +628,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -454,6 +657,7 @@
                 public void Should_Throw_If_File_Path_Is_Invalid(string filePath)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var line = 100;
@@ -472,6 +676,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -499,6 +704,7 @@
                 public void Should_Throw_If_File_Path_Is_Absolute(string filePath)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var line = 100;
@@ -517,6 +723,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -541,6 +748,7 @@
                 public void Should_Handle_File_Paths_Which_Are_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     string filePath = null;
@@ -560,6 +768,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -584,6 +793,7 @@
                 public void Should_Handle_File_Paths_Which_Are_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = string.Empty;
@@ -603,6 +813,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -627,6 +838,7 @@
                 public void Should_Handle_File_Paths_Which_Are_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = " ";
@@ -646,6 +858,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -679,6 +892,7 @@
                 public void Should_Set_File_Path(string filePath, string expectedFilePath)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var line = 10;
@@ -697,6 +911,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -725,6 +940,7 @@
                 public void Should_Throw_If_Line_Is_Negative()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -744,6 +960,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -768,6 +985,7 @@
                 public void Should_Throw_If_Line_Is_Zero()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -787,6 +1005,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -811,6 +1030,7 @@
                 public void Should_Throw_If_Line_Is_Set_But_No_File()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     string filePath = null;
@@ -830,6 +1050,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -854,6 +1075,7 @@
                 public void Should_Handle_Line_Which_Is_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -873,6 +1095,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -899,6 +1122,7 @@
                 public void Should_Set_Line(int line)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -917,6 +1141,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -944,6 +1169,7 @@
                 public void Should_Throw_If_Column_Is_Negative()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -963,6 +1189,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -987,6 +1214,7 @@
                 public void Should_Throw_If_Column_Is_Zero()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1006,6 +1234,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1030,6 +1259,7 @@
                 public void Should_Throw_If_Column_Is_Set_But_No_Line()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1049,6 +1279,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1076,6 +1307,7 @@
                 public void Should_Set_Column(int? column)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1094,6 +1326,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1121,6 +1354,7 @@
                 public void Should_Throw_If_MessageText_Is_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1140,6 +1374,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1164,6 +1399,7 @@
                 public void Should_Throw_If_MessageText_Is_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1183,6 +1419,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1207,6 +1444,7 @@
                 public void Should_Throw_If_MessageText_Is_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1226,6 +1464,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1251,6 +1490,7 @@
                 public void Should_Set_MessageText(string messageText)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1269,6 +1509,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1300,6 +1541,7 @@
                 public void Should_Set_MessageHtml(string messageHtml)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1318,6 +1560,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1349,6 +1592,7 @@
                 public void Should_Set_MessageHtml(string messageMarkdown)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1367,6 +1611,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1400,6 +1645,7 @@
                 public void Should_Set_Priority(int? priority)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1418,6 +1664,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1445,6 +1692,7 @@
                 public void Should_Handle_PriorityNames_Which_Are_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1464,6 +1712,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1488,6 +1737,7 @@
                 public void Should_Handle_PriorityNames_Which_Are_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1507,6 +1757,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1531,6 +1782,7 @@
                 public void Should_Handle_PriorityNames_Which_Are_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1550,6 +1802,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1575,6 +1828,7 @@
                 public void Should_Set_Priority_Name(string priorityName)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1593,6 +1847,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1623,6 +1878,7 @@
                 public void Should_Set_Rule(string rule)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1641,6 +1897,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1668,6 +1925,7 @@
                 public void Should_Set_Rule_Url()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1687,6 +1945,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1711,6 +1970,7 @@
                 public void Should_Set_Rule_Url_If_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1730,6 +1990,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1760,6 +2021,7 @@
                 public void Should_Set_Run(string run)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1778,6 +2040,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1805,6 +2068,7 @@
                 public void Should_Throw_If_Provider_Type_Is_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1824,6 +2088,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1848,6 +2113,7 @@
                 public void Should_Throw_If_Provider_Type_Is_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1867,6 +2133,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1891,6 +2158,7 @@
                 public void Should_Throw_If_Provider_Type_Is_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1910,6 +2178,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1935,6 +2204,7 @@
                 public void Should_Set_ProviderType(string providerType)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1953,6 +2223,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -1980,6 +2251,7 @@
                 public void Should_Throw_If_Provider_Name_Is_Null()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -1999,6 +2271,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -2023,6 +2296,7 @@
                 public void Should_Throw_If_Provider_Name_Is_Empty()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -2042,6 +2316,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -2066,6 +2341,7 @@
                 public void Should_Throw_If_Provider_Name_Is_WhiteSpace()
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -2085,6 +2361,7 @@
                     // When
                     var result = Record.Exception(() =>
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,
@@ -2110,6 +2387,7 @@
                 public void Should_Set_ProviderName(string providerName)
                 {
                     // Given
+                    var identifier = "identifier";
                     var projectPath = @"src\foo.csproj";
                     var projectName = "foo";
                     var filePath = @"src\foo.cs";
@@ -2128,6 +2406,7 @@
                     // When
                     var issue =
                         new Issue(
+                            identifier,
                             projectPath,
                             projectName,
                             filePath,

--- a/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
@@ -142,6 +142,7 @@
                 IssueChecker.Check(
                     result,
                     IssueBuilder.NewIssue(
+                        "Identifier",
                         "Something went wrong.",
                         "TestProvider",
                         "Test Provider")
@@ -265,6 +266,7 @@
                 IssueChecker.Check(
                     result[0],
                     IssueBuilder.NewIssue(
+                        "Identifier1",
                         "Something went wrong.",
                         "TestProvider",
                         "Test Provider")
@@ -277,6 +279,7 @@
                 IssueChecker.Check(
                     result[1],
                     IssueBuilder.NewIssue(
+                        "Identifier2",
                         "Something went wrong again.",
                         "TestProvider",
                         "Test Provider")

--- a/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
@@ -27,6 +27,23 @@
             }
 
             [Fact]
+            public void Should_Give_Correct_Result_For_Identifier_After_Roundtrip()
+            {
+                // Given
+                var identifier = "identifier";
+                var issue =
+                    IssueBuilder
+                        .NewIssue(identifier, "message", "providerType", "providerName")
+                        .Create();
+
+                // When
+                var result = issue.SerializeToJsonString().DeserializeToIssue();
+
+                // Then
+                result.Identifier.ShouldBe(identifier);
+            }
+
+            [Fact]
             public void Should_Give_Correct_Result_For_MessageText_After_Roundtrip()
             {
                 // Given
@@ -307,6 +324,32 @@
 
                 // Then
                 result.IsArgumentNullException("issues");
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_Identifier_After_Roundtrip()
+            {
+                // Given
+                var identifier1 = "identifier1";
+                var identifier2 = "identifier2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue(identifier1, "messageText1", "providerType1", "providerName1")
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue(identifier2, "messageText2", "providerType2", "providerName2")
+                            .Create(),
+                    };
+
+                // When
+                var result = issues.SerializeToJsonString().DeserializeToIssues();
+
+                // Then
+                result.Count().ShouldBe(2);
+                result.First().Identifier.ShouldBe(identifier1);
+                result.Last().Identifier.ShouldBe(identifier2);
             }
 
             [Fact]
@@ -755,6 +798,35 @@
 
                 // Then
                 result.IsArgumentNullException("filePath");
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_Identifier_After_Roundtrip()
+            {
+                // Given
+                var identifier = "identifier";
+                var issue =
+                    IssueBuilder
+                        .NewIssue(identifier, "messageText", "providerType", "providerName")
+                        .Create();
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issue.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssue();
+
+                    // Then
+                    result.Identifier.ShouldBe(identifier);
+                }
+                finally
+                {
+                    if (System.IO.File.Exists(filePath.FullPath))
+                    {
+                        System.IO.File.Delete(filePath.FullPath);
+                    }
+                }
             }
 
             [Fact]
@@ -1233,6 +1305,44 @@
 
                 // Then
                 result.IsArgumentNullException("filePath");
+            }
+
+            [Fact]
+            public void Should_Give_Correct_Result_For_Identifier_After_Roundtrip()
+            {
+                // Given
+                var identifier1 = "identifier1";
+                var identifier2 = "identifier2";
+                var issues =
+                    new List<IIssue>
+                    {
+                        IssueBuilder
+                          .NewIssue(identifier1, "messageText1", "providerType1", "providerName1")
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue(identifier2, "messageText2", "providerType2", "providerName2")
+                            .Create(),
+                    };
+                var filePath = new FilePath(System.IO.Path.GetTempPath() + Guid.NewGuid().ToString() + ".json");
+
+                try
+                {
+                    // When
+                    issues.SerializeToJsonFile(filePath);
+                    var result = filePath.DeserializeToIssues();
+
+                    // Then
+                    result.Count().ShouldBe(2);
+                    result.First().Identifier.ShouldBe(identifier1);
+                    result.Last().Identifier.ShouldBe(identifier2);
+                }
+                finally
+                {
+                    if (System.IO.File.Exists(filePath.FullPath))
+                    {
+                        System.IO.File.Delete(filePath.FullPath);
+                    }
+                }
             }
 
             [Fact]

--- a/src/Cake.Issues.Tests/Testfiles/issueV3.json
+++ b/src/Cake.Issues.Tests/Testfiles/issueV3.json
@@ -1,5 +1,6 @@
 {
   "Version": 3,
+  "Identifier":  "Identifier",
   "AffectedFileRelativePath": "src\/Foo\/Bar.cs",
   "Line": 42,
   "Column": 23,

--- a/src/Cake.Issues.Tests/Testfiles/issuesV3.json
+++ b/src/Cake.Issues.Tests/Testfiles/issuesV3.json
@@ -1,6 +1,7 @@
 [
   {
     "Version": 3,
+    "Identifier": "Identifier1",
     "AffectedFileRelativePath": "src\/Foo\/Bar.cs",
     "Line": 42,
     "Column": 23,
@@ -18,6 +19,7 @@
   },
   {
     "Version": 3,
+    "Identifier": "Identifier2",
     "AffectedFileRelativePath": "src\/Foo\/Bar2.cs",
     "Line": null,
     "Column": null,

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
@@ -5,16 +5,17 @@
     internal class IssueCheckerFixture : IssueBuilderFixture
     {
         public IssueCheckerFixture()
-            : this("Message", "ProviderType", "ProviderName")
+            : this("Identifier", "Message", "ProviderType", "ProviderName")
         {
         }
 
-        public IssueCheckerFixture(string messageText, string providerType, string providerName)
-            : base(messageText, providerType, providerName)
+        public IssueCheckerFixture(string identifier, string messageText, string providerType, string providerName)
+            : base(identifier, messageText, providerType, providerName)
         {
             this.ProviderType = providerType;
             this.ProviderName = providerName;
             this.Run = "Test Run";
+            this.Identifier = identifier;
             this.ProjectFileRelativePath = @"src\project.file";
             this.ProjectName = "ProjectName";
             this.AffectedFileRelativePath = @"src\source.file";
@@ -48,6 +49,8 @@
         public string ProviderName { get; private set; }
 
         public string Run { get; private set; }
+
+        public string Identifier { get; private set; }
 
         public string ProjectFileRelativePath { get; private set; }
 

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
@@ -145,6 +145,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -174,6 +175,7 @@
                     fixture.ProviderType,
                     fixture.ProviderName,
                     fixture.Run,
+                    fixture.Identifier,
                     fixture.ProjectFileRelativePath,
                     fixture.ProjectName,
                     fixture.AffectedFileRelativePath,
@@ -198,7 +200,7 @@
             public void Should_Throw_If_ProviderType_Is_Different(string expectedValue, string actualValue)
             {
                 // Given
-                var fixture = new IssueCheckerFixture("Message", actualValue, "ProviderName");
+                var fixture = new IssueCheckerFixture("Identifier", "Message", actualValue, "ProviderName");
 
                 // When
                 var result = Record.Exception(() =>
@@ -207,6 +209,7 @@
                         expectedValue,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -233,7 +236,7 @@
             public void Should_Throw_If_ProviderName_Is_Different(string expectedValue, string actualValue)
             {
                 // Given
-                var fixture = new IssueCheckerFixture("Message", "ProviderType", actualValue);
+                var fixture = new IssueCheckerFixture("Identifier", "Message", "ProviderType", actualValue);
 
                 // When
                 var result = Record.Exception(() =>
@@ -242,6 +245,7 @@
                         fixture.ProviderType,
                         expectedValue,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -281,6 +285,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         expectedValue,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -297,6 +302,42 @@
                 // Then
                 result.ShouldBeOfType<Exception>();
                 result.Message.ShouldStartWith("Expected issue.Run");
+            }
+
+            [Theory]
+            [InlineData("Message", "Foo")]
+            [InlineData(null, "Foo")]
+            [InlineData("", "Foo")]
+            [InlineData(" ", "Foo")]
+            public void Should_Throw_If_Identifier_Is_Different(string expectedValue, string actualValue)
+            {
+                // Given
+                var fixture = new IssueCheckerFixture(actualValue, "Message", "ProviderType", "ProviderName");
+
+                // When
+                var result = Record.Exception(() =>
+                    IssueChecker.Check(
+                        fixture.Issue,
+                        fixture.ProviderType,
+                        fixture.ProviderName,
+                        fixture.Run,
+                        expectedValue,
+                        fixture.ProjectFileRelativePath,
+                        fixture.ProjectName,
+                        fixture.AffectedFileRelativePath,
+                        fixture.Line,
+                        fixture.Column,
+                        fixture.MessageText,
+                        fixture.MessageHtml,
+                        fixture.MessageMarkdown,
+                        fixture.Priority,
+                        fixture.PriorityName,
+                        fixture.Rule,
+                        fixture.RuleUrl));
+
+                // Then
+                result.ShouldBeOfType<Exception>();
+                result.Message.ShouldStartWith("Expected issue.Identifier");
             }
 
             [Theory]
@@ -317,6 +358,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         expectedValue,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -356,6 +398,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         expectedValue,
                         fixture.AffectedFileRelativePath,
@@ -392,6 +435,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         expectedValue,
@@ -430,6 +474,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -468,6 +513,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -494,7 +540,7 @@
             public void Should_Throw_If_MessageText_Is_Different(string expectedValue, string actualValue)
             {
                 // Given
-                var fixture = new IssueCheckerFixture(actualValue, "ProviderType", "ProviderName");
+                var fixture = new IssueCheckerFixture("Identifier", actualValue, "ProviderType", "ProviderName");
 
                 // When
                 var result = Record.Exception(() =>
@@ -503,6 +549,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -542,6 +589,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -581,6 +629,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -617,6 +666,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -656,6 +706,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -695,6 +746,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,
@@ -731,6 +783,7 @@
                         fixture.ProviderType,
                         fixture.ProviderName,
                         fixture.Run,
+                        fixture.Identifier,
                         fixture.ProjectFileRelativePath,
                         fixture.ProjectName,
                         fixture.AffectedFileRelativePath,

--- a/src/Cake.Issues/Aliases.NewIssue.cs
+++ b/src/Cake.Issues/Aliases.NewIssue.cs
@@ -9,7 +9,7 @@
     public static partial class Aliases
     {
         /// <summary>
-        /// Initiates the creation of a new <see cref="IIssue"/>.
+        /// Initiates the creation of a new <see cref="IIssue"/> with <paramref name="message"/> as identifier.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="message">The message of the issue.</param>
@@ -45,6 +45,55 @@
             providerName.NotNullOrWhiteSpace(nameof(providerName));
 
             return IssueBuilder.NewIssue(message, providerType, providerName);
+        }
+
+        /// <summary>
+        /// Initiates the creation of a new <see cref="IIssue"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="identifier">The identifier of the issue.</param>
+        /// <param name="message">The message of the issue.</param>
+        /// <param name="providerType">The unique identifier of the issue provider.</param>
+        /// <param name="providerName">The human friendly name of the issue provider.</param>
+        /// <returns>Builder class for creating a new <see cref="IIssue"/>.</returns>
+        /// <example>
+        /// <para>Create a new warning for the myfile.txt file on line 42:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var issue =
+        ///         NewIssue(
+        ///             "Issue identifier",
+        ///             "Something went wrong",
+        ///             "MyCakeScript",
+        ///             "My Cake Script")
+        ///             .InFile("myfile.txt", 42)
+        ///             .WithPriority(IssuePriority.Warning)
+        ///             .Create();
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.CreateCakeAliasCategory)]
+        public static IssueBuilder NewIssue(
+            this ICakeContext context,
+            string identifier,
+            string message,
+            string providerType,
+            string providerName)
+        {
+#pragma warning disable SA1123 // Do not place regions within elements
+            #region DupFinder Exclusion
+#pragma warning restore SA1123 // Do not place regions within elements
+
+            context.NotNull(nameof(context));
+            identifier.NotNullOrWhiteSpace(nameof(identifier));
+            message.NotNullOrWhiteSpace(nameof(message));
+            providerType.NotNullOrWhiteSpace(nameof(providerType));
+            providerName.NotNullOrWhiteSpace(nameof(providerName));
+
+            #endregion
+
+            return IssueBuilder.NewIssue(identifier, message, providerType, providerName);
         }
     }
 }

--- a/src/Cake.Issues/IIssue.cs
+++ b/src/Cake.Issues/IIssue.cs
@@ -9,6 +9,12 @@
     public interface IIssue
     {
         /// <summary>
+        /// Gets the identifier for the message.
+        /// The identifier can be used to identify the same issue across multiple runs.
+        /// </summary>
+        string Identifier { get;  }
+
+        /// <summary>
         /// Gets the path to the project to which the file affected by the issue belongs.
         /// The path is relative to the repository root.
         /// Can be <c>null</c> if issue is not related to a project.

--- a/src/Cake.Issues/IIssueComparer.cs
+++ b/src/Cake.Issues/IIssueComparer.cs
@@ -62,6 +62,7 @@
             }
 
             return
+                (x.Identifier == y.Identifier) &&
                 (this.compareOnlyPersistentProperties || x.ProjectFileRelativePath?.FullPath == y.ProjectFileRelativePath?.FullPath) &&
                 (x.ProjectName == y.ProjectName) &&
                 (this.compareOnlyPersistentProperties || x.AffectedFileRelativePath?.FullPath == y.AffectedFileRelativePath?.FullPath) &&
@@ -91,6 +92,7 @@
             {
                 return
                     GetHashCode(
+                        obj.Identifier,
                         obj.ProjectName,
                         obj.MessageText,
                         obj.MessageHtml,
@@ -107,6 +109,7 @@
             {
                 return
                     GetHashCode(
+                        obj.Identifier,
                         obj.ProjectFileRelativePath?.ToString(),
                         obj.ProjectName,
                         obj.AffectedFileRelativePath?.ToString(),

--- a/src/Cake.Issues/IIssueExtensions.cs
+++ b/src/Cake.Issues/IIssueExtensions.cs
@@ -108,6 +108,10 @@
         ///         <description>The value of <see cref="IIssue.ProviderName"/>.</description>
         ///     </item>
         ///     <item>
+        ///         <term>{Identifier}</term>
+        ///         <description>The value of <see cref="IIssue.Identifier"/>.</description>
+        ///     </item>
+        ///     <item>
         ///         <term>{Priority}</term>
         ///         <description>The value of <see cref="IIssue.Priority"/>.</description>
         ///     </item>
@@ -186,6 +190,7 @@
                 pattern
                     .Replace("{ProviderType}", issue.ProviderType)
                     .Replace("{ProviderName}", issue.ProviderName)
+                    .Replace("{Identifier}", issue.Identifier)
                     .Replace("{Priority}", issue.Priority?.ToString())
                     .Replace("{PriorityName}", issue.PriorityName)
                     .Replace("{ProjectPath}", issue.ProjectPath())

--- a/src/Cake.Issues/Issue.cs
+++ b/src/Cake.Issues/Issue.cs
@@ -11,6 +11,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Issue"/> class.
         /// </summary>
+        /// <param name="identifier">The identifier of the issue.
+        /// The identifier needs to be identical across multiple runs of an issue provider for the same issue.</param>
         /// <param name="projectFileRelativePath">The path to the project to which the file affected by the issue belongs.
         /// The path needs to be relative to the repository root.
         /// Can be <c>null</c> or <see cref="string.Empty"/> if issue is not related to a project.</param>
@@ -38,6 +40,7 @@
         /// <param name="providerType">The type of the issue provider.</param>
         /// <param name="providerName">The human friendly name of the issue provider.</param>
         public Issue(
+            string identifier,
             string projectFileRelativePath,
             string projectName,
             string affectedFileRelativePath,
@@ -54,6 +57,7 @@
             string providerType,
             string providerName)
         {
+            identifier.NotNullOrWhiteSpace(nameof(identifier));
             line?.NotNegativeOrZero(nameof(line));
             column?.NotNegativeOrZero(nameof(column));
             messageText.NotNullOrWhiteSpace(nameof(messageText));
@@ -106,6 +110,7 @@
                 throw new ArgumentOutOfRangeException(nameof(column), $"Cannot specify a column while not specifying a line.");
             }
 
+            this.Identifier = identifier;
             this.ProjectName = projectName;
             this.Line = line;
             this.Column = column;
@@ -120,6 +125,9 @@
             this.ProviderType = providerType;
             this.ProviderName = providerName;
         }
+
+        /// <inheritdoc/>
+        public string Identifier { get; }
 
         /// <inheritdoc/>
         public FilePath ProjectFileRelativePath { get; }

--- a/src/Cake.Issues/IssueBuilder.cs
+++ b/src/Cake.Issues/IssueBuilder.cs
@@ -7,6 +7,7 @@
     /// </summary>
     public class IssueBuilder
     {
+        private readonly string identifier;
         private readonly string providerType;
         private readonly string providerName;
         private readonly string messageText;
@@ -26,44 +27,36 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="IssueBuilder"/> class.
         /// </summary>
+        /// <param name="identifier">The identifier of the message.</param>
         /// <param name="message">The message of the issue in plain text format.</param>
         /// <param name="providerType">The type of the issue provider.</param>
         /// <param name="providerName">The human friendly name of the issue provider.</param>
         private IssueBuilder(
+            string identifier,
             string message,
             string providerType,
             string providerName)
         {
+#pragma warning disable SA1123 // Do not place regions within elements
+            #region DupFinder Exclusion
+#pragma warning restore SA1123 // Do not place regions within elements
+
+            identifier.NotNullOrWhiteSpace(nameof(identifier));
             message.NotNullOrWhiteSpace(nameof(message));
             providerType.NotNullOrWhiteSpace(nameof(providerType));
             providerName.NotNullOrWhiteSpace(nameof(providerName));
 
+            #endregion
+
+            this.identifier = identifier;
             this.messageText = message;
             this.providerType = providerType;
             this.providerName = providerName;
         }
 
         /// <summary>
-        /// Initiates the creation of a new <see cref="IIssue"/>.
-        /// </summary>
-        /// <param name="message">The message of the issue in plain text format.</param>
-        /// <param name="providerType">The type of the issue provider.</param>
-        /// <param name="providerName">The human friendly name of the issue provider.</param>
-        /// <returns>Builder class for creating a new issue.</returns>
-        public static IssueBuilder NewIssue(
-            string message,
-            string providerType,
-            string providerName)
-        {
-            message.NotNullOrWhiteSpace(nameof(message));
-            providerType.NotNullOrWhiteSpace(nameof(providerType));
-            providerName.NotNullOrWhiteSpace(nameof(providerName));
-
-            return new IssueBuilder(message, providerType, providerName);
-        }
-
-        /// <summary>
-        /// Initiates the creation of a new <see cref="IIssue"/>.
+        /// Initiates the creation of a new <see cref="IIssue"/> with <paramref name="message"/>
+        /// as identifier.
         /// </summary>
         /// <typeparam name="T">Type of the issue provider which has the issue created.</typeparam>
         /// <param name="message">The message of the issue in plain text format.</param>
@@ -81,7 +74,78 @@
 
             message.NotNullOrWhiteSpace(nameof(message));
 
-            return new IssueBuilder(message, typeof(T).FullName, issueProvider.ProviderName);
+            return NewIssue(message, message, issueProvider);
+        }
+
+        /// <summary>
+        /// Initiates the creation of a new <see cref="IIssue"/>.
+        /// </summary>
+        /// <typeparam name="T">Type of the issue provider which has the issue created.</typeparam>
+        /// <param name="identifier">The identifier of the message.</param>
+        /// <param name="message">The message of the issue in plain text format.</param>
+        /// <param name="issueProvider">Issue provider which has the issue created.</param>
+        /// <returns>Builder class for creating a new issue.</returns>
+        public static IssueBuilder NewIssue<T>(
+            string identifier,
+            string message,
+            T issueProvider)
+            where T : IIssueProvider
+        {
+            if (issueProvider == null)
+            {
+                throw new ArgumentNullException(nameof(issueProvider));
+            }
+
+            message.NotNullOrWhiteSpace(nameof(message));
+
+            return NewIssue(identifier, message, typeof(T).FullName, issueProvider.ProviderName);
+        }
+
+        /// <summary>
+        /// Initiates the creation of a new <see cref="IIssue"/> with <paramref name="message"/> as identifier.
+        /// </summary>
+        /// <param name="message">The message of the issue in plain text format.</param>
+        /// <param name="providerType">The type of the issue provider.</param>
+        /// <param name="providerName">The human friendly name of the issue provider.</param>
+        /// <returns>Builder class for creating a new issue.</returns>
+        public static IssueBuilder NewIssue(
+            string message,
+            string providerType,
+            string providerName)
+        {
+            message.NotNullOrWhiteSpace(nameof(message));
+            providerType.NotNullOrWhiteSpace(nameof(providerType));
+            providerName.NotNullOrWhiteSpace(nameof(providerName));
+
+            return NewIssue(message, message, providerType, providerName);
+        }
+
+        /// <summary>
+        /// Initiates the creation of a new <see cref="IIssue"/>.
+        /// </summary>
+        /// <param name="identifier">The identifier of the message.</param>
+        /// <param name="message">The message of the issue in plain text format.</param>
+        /// <param name="providerType">The type of the issue provider.</param>
+        /// <param name="providerName">The human friendly name of the issue provider.</param>
+        /// <returns>Builder class for creating a new issue.</returns>
+        public static IssueBuilder NewIssue(
+            string identifier,
+            string message,
+            string providerType,
+            string providerName)
+        {
+#pragma warning disable SA1123 // Do not place regions within elements
+            #region DupFinder Exclusion
+#pragma warning restore SA1123 // Do not place regions within elements
+
+            identifier.NotNullOrWhiteSpace(nameof(identifier));
+            message.NotNullOrWhiteSpace(nameof(message));
+            providerType.NotNullOrWhiteSpace(nameof(providerType));
+            providerName.NotNullOrWhiteSpace(nameof(providerName));
+
+            #endregion
+
+            return new IssueBuilder(identifier, message, providerType, providerName);
         }
 
         /// <summary>
@@ -287,6 +351,7 @@
         {
             return
                 new Issue(
+                    this.identifier,
                     this.projectFileRelativePath,
                     this.projectName,
                     this.filePath,

--- a/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
+++ b/src/Cake.Issues/Serialization/IssueSerializationExtensions.cs
@@ -80,6 +80,7 @@
 
             return new SerializableIssueV3
             {
+                Identifier = issue.Identifier,
                 ProjectFileRelativePath = issue.ProjectFileRelativePath?.FullPath,
                 ProjectName = issue.ProjectName,
                 AffectedFileRelativePath = issue.AffectedFileRelativePath?.FullPath,

--- a/src/Cake.Issues/Serialization/SerializableIssueExtensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueExtensions.cs
@@ -27,6 +27,7 @@
             }
 
             return new Issue(
+                serializableIssue.Message,
                 serializableIssue.ProjectFileRelativePath,
                 serializableIssue.ProjectName,
                 serializableIssue.AffectedFileRelativePath,

--- a/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
@@ -27,6 +27,7 @@
             }
 
             return new Issue(
+                serializableIssue.MessageText,
                 serializableIssue.ProjectFileRelativePath,
                 serializableIssue.ProjectName,
                 serializableIssue.AffectedFileRelativePath,

--- a/src/Cake.Issues/Serialization/SerializableIssueV3.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV3.cs
@@ -20,6 +20,10 @@
             }
         }
 
+        /// <inheritdoc cref="IIssue.Identifier" />
+        [DataMember]
+        public string Identifier { get; set; }
+
         /// <inheritdoc cref="IIssue.ProjectFileRelativePath" />
         [DataMember]
         public string ProjectFileRelativePath { get; set; }

--- a/src/Cake.Issues/Serialization/SerializableIssueV3Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV3Extensions.cs
@@ -27,6 +27,7 @@
             }
 
             return new Issue(
+                serializableIssue.Identifier,
                 serializableIssue.ProjectFileRelativePath,
                 serializableIssue.ProjectName,
                 serializableIssue.AffectedFileRelativePath,


### PR DESCRIPTION
Add additional property `IIssue.Identifier` which can be used to identify an issue across multiple runs. One use case is for pull request integration where until now `IIssue.MessageText` was used, which doesn't work reliable in case message contains information which changes between runs (e.g. dupFinder reports line information in the message).

Fixes #170 