### PR TITLE
Possibility to use a commit id instead of branch name for file-linking

### DIFF
--- a/src/Cake.Issues.Tests/FileLinkSettingsTests.cs
+++ b/src/Cake.Issues.Tests/FileLinkSettingsTests.cs
@@ -7,7 +7,7 @@
 
     public sealed class FileLinkSettingsTests
     {
-        public sealed class TheGitHubMethod
+        public sealed class TheGitHubBranchMethod
         {
             [Fact]
             public void Should_Throw_If_RepositoryUrl_Is_Null()
@@ -19,7 +19,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.GitHub(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.GitHubBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentNullException("repositoryUrl");
@@ -35,7 +35,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.GitHub(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.GitHubBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentNullException("branch");
@@ -51,7 +51,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.GitHub(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.GitHubBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentOutOfRangeException("branch");
@@ -67,7 +67,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.GitHub(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.GitHubBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentOutOfRangeException("branch");
@@ -85,14 +85,99 @@
                 // Given
 
                 // When
-                var result = FileLinkSettings.GitHub(new Uri(repositoryUrl), branch, rootPath);
+                var result = FileLinkSettings.GitHubBranch(new Uri(repositoryUrl), branch, rootPath);
 
                 // Then
                 result.FileLinkPattern.ShouldBe(expectedPattern);
             }
         }
 
-        public sealed class TheAzureDevOpsMethod
+        public sealed class TheGitHubCommitMethod
+        {
+            [Fact]
+            public void Should_Throw_If_RepositoryUrl_Is_Null()
+            {
+                // Given
+                Uri repositoryUrl = null;
+                var commitId = "87eaf0a0cf1746179e8714eae4114d10";
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.GitHubCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentNullException("repositoryUrl");
+            }
+
+            [Fact]
+            public void Should_Throw_If_CommitId_Is_Null()
+            {
+                // Given
+                var repositoryUrl = new Uri("https://github.com/cake-contrib/Cake.Issues.Website");
+                string commitId = null;
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.GitHubCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentNullException("commitId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_CommitId_Is_Empty()
+            {
+                // Given
+                var repositoryUrl = new Uri("https://github.com/cake-contrib/Cake.Issues.Website");
+                var commitId = string.Empty;
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.GitHubCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentOutOfRangeException("commitId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_CommitId_Is_Whitespace()
+            {
+                // Given
+                var repositoryUrl = new Uri("https://github.com/cake-contrib/Cake.Issues.Website");
+                var commitId = " ";
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.GitHubCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentOutOfRangeException("commitId");
+            }
+
+            [Theory]
+            [InlineData("https://github.com/cake-contrib/Cake.Issues.Website", "87eaf0a0cf1746179e8714eae4114d10", null, "https://github.com/cake-contrib/Cake.Issues.Website/blob/87eaf0a0cf1746179e8714eae4114d10/{FilePath}#L{Line}")]
+            [InlineData("https://github.com/cake-contrib/Cake.Issues.Website/", "87eaf0a0cf1746179e8714eae4114d10", null, "https://github.com/cake-contrib/Cake.Issues.Website/blob/87eaf0a0cf1746179e8714eae4114d10/{FilePath}#L{Line}")]
+            [InlineData("https://github.com/cake-contrib/Cake.Issues.Website", "87eaf0a0cf1746179e8714eae4114d10", "foo", "https://github.com/cake-contrib/Cake.Issues.Website/blob/87eaf0a0cf1746179e8714eae4114d10/foo/{FilePath}#L{Line}")]
+            [InlineData("https://github.com/cake-contrib/Cake.Issues.Website", "87eaf0a0cf1746179e8714eae4114d10", "/foo", "https://github.com/cake-contrib/Cake.Issues.Website/blob/87eaf0a0cf1746179e8714eae4114d10/foo/{FilePath}#L{Line}")]
+            [InlineData("https://github.com/cake-contrib/Cake.Issues.Website", "87eaf0a0cf1746179e8714eae4114d10", "foo/", "https://github.com/cake-contrib/Cake.Issues.Website/blob/87eaf0a0cf1746179e8714eae4114d10/foo/{FilePath}#L{Line}")]
+            [InlineData("https://github.com/cake-contrib/Cake.Issues.Website", "87eaf0a0cf1746179e8714eae4114d10", "foo/bar", "https://github.com/cake-contrib/Cake.Issues.Website/blob/87eaf0a0cf1746179e8714eae4114d10/foo/bar/{FilePath}#L{Line}")]
+            public void Should_Set_Correct_FileLinkPattern(string repositoryUrl, string commitId, string rootPath, string expectedPattern)
+            {
+                // Given
+
+                // When
+                var result = FileLinkSettings.GitHubCommit(new Uri(repositoryUrl), commitId, rootPath);
+
+                // Then
+                result.FileLinkPattern.ShouldBe(expectedPattern);
+            }
+        }
+
+        public sealed class TheAzureDevOpsBranchMethod
         {
             [Fact]
             public void Should_Throw_If_RepositoryUrl_Is_Null()
@@ -104,7 +189,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.AzureDevOps(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.AzureDevOpsBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentNullException("repositoryUrl");
@@ -120,7 +205,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.AzureDevOps(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.AzureDevOpsBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentNullException("branch");
@@ -136,7 +221,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.AzureDevOps(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.AzureDevOpsBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentOutOfRangeException("branch");
@@ -152,7 +237,7 @@
 
                 // When
                 var result = Record.Exception(() =>
-                    FileLinkSettings.AzureDevOps(repositoryUrl, branch, rootPath));
+                    FileLinkSettings.AzureDevOpsBranch(repositoryUrl, branch, rootPath));
 
                 // Then
                 result.IsArgumentOutOfRangeException("branch");
@@ -171,7 +256,88 @@
                 // Given
 
                 // When
-                var result = FileLinkSettings.AzureDevOps(new Uri(repositoryUrl), branch, rootPath);
+                var result = FileLinkSettings.AzureDevOpsBranch(new Uri(repositoryUrl), branch, rootPath);
+
+                // Then
+                result.FileLinkPattern.ShouldBe(expectedPattern);
+            }
+        }
+
+        public sealed class TheAzureDevOpsCommitMethod
+        {
+            [Fact]
+            public void Should_Throw_If_RepositoryUrl_Is_Null()
+            {
+                // Given
+                Uri repositoryUrl = null;
+                var branch = "master";
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.AzureDevOpsBranch(repositoryUrl, branch, rootPath));
+
+                // Then
+                result.IsArgumentNullException("repositoryUrl");
+            }
+
+            [Fact]
+            public void Should_Throw_If_CommitId_Is_Null()
+            {
+                // Given
+                var repositoryUrl = new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository");
+                string commitId = null;
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.AzureDevOpsCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentNullException("commitId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_CommitId_Is_Empty()
+            {
+                // Given
+                var repositoryUrl = new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository");
+                var commitId = string.Empty;
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.AzureDevOpsCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentOutOfRangeException("commitId");
+            }
+
+            [Fact]
+            public void Should_Throw_If_CommitId_Is_Whitespace()
+            {
+                // Given
+                var repositoryUrl = new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository");
+                var commitId = " ";
+                var rootPath = string.Empty;
+
+                // When
+                var result = Record.Exception(() =>
+                    FileLinkSettings.AzureDevOpsCommit(repositoryUrl, commitId, rootPath));
+
+                // Then
+                result.IsArgumentOutOfRangeException("commitId");
+            }
+
+            [Theory]
+            [InlineData("https://dev.azure.com/myorganization/_git/myrepo", "daf015105140e98d6f296e0db2a80d28b84e7f59", null, "https://dev.azure.com/myorganization/_git/myrepo?path={FilePath}&version=GCdaf015105140e98d6f296e0db2a80d28b84e7f59&line={Line}&lineEnd={EndLine}&lineStartColumn={Column}&lineEndColumn={EndColumn}")]
+            [InlineData("https://dev.azure.com/myorganization/_git/myrepo", "daf015105140e98d6f296e0db2a80d28b84e7f59", "foo/bar", "https://dev.azure.com/myorganization/_git/myrepo?path=foo/bar/{FilePath}&version=GCdaf015105140e98d6f296e0db2a80d28b84e7f59&line={Line}&lineEnd={EndLine}&lineStartColumn={Column}&lineEndColumn={EndColumn}")]
+            public void Should_Set_Correct_FileLinkPattern(string repositoryUrl, string commitId, string rootPath, string expectedPattern)
+            {
+                // Given
+
+                // When
+                var result = FileLinkSettings.AzureDevOpsCommit(new Uri(repositoryUrl), commitId, rootPath);
 
                 // Then
                 result.FileLinkPattern.ShouldBe(expectedPattern);

--- a/src/Cake.Issues.Tests/IssueReaderTests.cs
+++ b/src/Cake.Issues.Tests/IssueReaderTests.cs
@@ -367,7 +367,7 @@
                 var repoUrl = "https://github.com/cake-contrib/Cake.Issues.Website";
                 var branch = "develop";
                 fixture.Settings.FileLinkSettings =
-                    FileLinkSettings.GitHub(
+                    FileLinkSettings.GitHubBranch(
                         new System.Uri(repoUrl),
                         branch,
                         null);

--- a/src/Cake.Issues/Aliases.FileLinking.cs
+++ b/src/Cake.Issues/Aliases.FileLinking.cs
@@ -10,16 +10,16 @@
     public static partial class Aliases
     {
         /// <summary>
-        /// Gets an instance of the file link settings for linking files hosted on GitHub.
+        /// Gets an instance of the file link settings for linking files hosted on GitHub on a specific branch.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// eg. <code>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic</code>.</param>
-        /// <param name="branch">Name of the branch.</param>
+        /// <param name="branch">Name of the branch on which the file linking will be based on.</param>
         /// <returns>Settings for linking to files hosted in GitHub.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
-        public static FileLinkSettings IssueFileLinkSettingsForGitHub(
+        public static FileLinkSettings IssueFileLinkSettingsForGitHubBranch(
             this ICakeContext context,
             Uri repositoryUrl,
             string branch)
@@ -28,22 +28,23 @@
             repositoryUrl.NotNull(nameof(repositoryUrl));
             branch.NotNullOrWhiteSpace(nameof(branch));
 
-            return context.IssueFileLinkSettingsForGitHub(repositoryUrl, branch, null);
+            return context.IssueFileLinkSettingsForGitHubBranch(repositoryUrl, branch, null);
         }
 
         /// <summary>
-        /// Gets an instance of the file link settings for linking files hosted on GitHub in a sub-folder.
+        /// Gets an instance of the file link settings for linking files hosted on GitHub
+        /// in a sub-folder on a specific branch.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// eg. <code>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic</code>.</param>
-        /// <param name="branch">Name of the branch.</param>
+        /// <param name="branch">Name of the branch on which the file linking will be based on.</param>
         /// <param name="rootPath">Root path of the files.
         /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
         /// <returns>Settings for linking to files hosted in GitHub.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
-        public static FileLinkSettings IssueFileLinkSettingsForGitHub(
+        public static FileLinkSettings IssueFileLinkSettingsForGitHubBranch(
             this ICakeContext context,
             Uri repositoryUrl,
             string branch,
@@ -53,20 +54,69 @@
             repositoryUrl.NotNull(nameof(repositoryUrl));
             branch.NotNullOrWhiteSpace(nameof(branch));
 
-            return FileLinkSettings.GitHub(repositoryUrl, branch, rootPath);
+            return FileLinkSettings.GitHubBranch(repositoryUrl, branch, rootPath);
         }
 
         /// <summary>
-        /// Gets an instance of the file link settings for linking to files hosted in Azure DevOps.
+        /// Gets an instance of the file link settings for linking files hosted on GitHub fo a specific commit.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryUrl">Full URL of the Git repository,
+        /// eg. <code>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic</code>.</param>
+        /// <param name="commitId">The commit id on which the file linking will be based on.</param>
+        /// <returns>Settings for linking to files hosted in GitHub.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
+        public static FileLinkSettings IssueFileLinkSettingsForGitHubCommit(
+            this ICakeContext context,
+            Uri repositoryUrl,
+            string commitId)
+        {
+            context.NotNull(nameof(context));
+            repositoryUrl.NotNull(nameof(repositoryUrl));
+            commitId.NotNullOrWhiteSpace(nameof(commitId));
+
+            return context.IssueFileLinkSettingsForGitHubCommit(repositoryUrl, commitId, null);
+        }
+
+        /// <summary>
+        /// Gets an instance of the file link settings for linking files hosted on GitHub
+        /// in a sub-folder for a specific commit.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryUrl">Full URL of the Git repository,
+        /// eg. <code>https://github.com/cake-contrib/Cake.Issues.Reporting.Generic</code>.</param>
+        /// <param name="commitId">The commit id on which the file linking will be based on.</param>
+        /// <param name="rootPath">Root path of the files.
+        /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
+        /// <returns>Settings for linking to files hosted in GitHub.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
+        public static FileLinkSettings IssueFileLinkSettingsForGitHubCommit(
+            this ICakeContext context,
+            Uri repositoryUrl,
+            string commitId,
+            string rootPath)
+        {
+            context.NotNull(nameof(context));
+            repositoryUrl.NotNull(nameof(repositoryUrl));
+            commitId.NotNullOrWhiteSpace(nameof(commitId));
+
+            return FileLinkSettings.GitHubCommit(repositoryUrl, commitId, rootPath);
+        }
+
+        /// <summary>
+        /// Gets an instance of the file link settings for linking to files hosted in Azure DevOps
+        /// on a specific branch.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// eg. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
-        /// <param name="branch">Name of the branch.</param>
+        /// <param name="branch">Name of the branch on which the file linking will be based on.</param>
         /// <returns>Settings for linking files hosted on Azure DevOps or Azure DevOps Server.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
-        public static FileLinkSettings IssueFileLinkSettingsForAzureDevOps(
+        public static FileLinkSettings IssueFileLinkSettingsForAzureDevOpsBranch(
             this ICakeContext context,
             Uri repositoryUrl,
             string branch)
@@ -75,22 +125,23 @@
             repositoryUrl.NotNull(nameof(repositoryUrl));
             branch.NotNullOrWhiteSpace(nameof(branch));
 
-            return context.IssueFileLinkSettingsForAzureDevOps(repositoryUrl, branch, null);
+            return context.IssueFileLinkSettingsForAzureDevOpsBranch(repositoryUrl, branch, null);
         }
 
         /// <summary>
-        /// Gets an instance of the file link settings for linking to files hosted in Azure DevOps in a sub-folder.
+        /// Gets an instance of the file link settings for linking to files hosted in Azure DevOps
+        /// in a sub-folder on a specific branch.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// eg. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
-        /// <param name="branch">Name of the branch.</param>
+        /// <param name="branch">Name of the branch on which the file linking will be based on.</param>
         /// <param name="rootPath">Root path of the files.
         /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
         /// <returns>Settings for linking files hosted on Azure DevOps.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
-        public static FileLinkSettings IssueFileLinkSettingsForAzureDevOps(
+        public static FileLinkSettings IssueFileLinkSettingsForAzureDevOpsBranch(
             this ICakeContext context,
             Uri repositoryUrl,
             string branch,
@@ -100,7 +151,56 @@
             repositoryUrl.NotNull(nameof(repositoryUrl));
             branch.NotNullOrWhiteSpace(nameof(branch));
 
-            return FileLinkSettings.AzureDevOps(repositoryUrl, branch, rootPath);
+            return FileLinkSettings.AzureDevOpsBranch(repositoryUrl, branch, rootPath);
+        }
+
+        /// <summary>
+        /// Gets an instance of the file link settings for linking to files hosted in Azure DevOps
+        /// for a specific commit.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryUrl">Full URL of the Git repository,
+        /// eg. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
+        /// <param name="commitId">The commit id on which the file linking will be based on.</param>
+        /// <returns>Settings for linking files hosted on Azure DevOps or Azure DevOps Server.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
+        public static FileLinkSettings IssueFileLinkSettingsForAzureDevOpsCommit(
+            this ICakeContext context,
+            Uri repositoryUrl,
+            string commitId)
+        {
+            context.NotNull(nameof(context));
+            repositoryUrl.NotNull(nameof(repositoryUrl));
+            commitId.NotNullOrWhiteSpace(nameof(commitId));
+
+            return context.IssueFileLinkSettingsForAzureDevOpsCommit(repositoryUrl, commitId, null);
+        }
+
+        /// <summary>
+        /// Gets an instance of the file link settings for linking to files hosted in Azure DevOps
+        /// in a sub-folder for a specific commit.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryUrl">Full URL of the Git repository,
+        /// eg. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
+        /// <param name="commitId">The commit id on which the file linking will be based on.</param>
+        /// <param name="rootPath">Root path of the files.
+        /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
+        /// <returns>Settings for linking files hosted on Azure DevOps.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(IssuesAliasConstants.FileLinkingCakeAliasCategory)]
+        public static FileLinkSettings IssueFileLinkSettingsForAzureDevOpsCommit(
+            this ICakeContext context,
+            Uri repositoryUrl,
+            string commitId,
+            string rootPath)
+        {
+            context.NotNull(nameof(context));
+            repositoryUrl.NotNull(nameof(repositoryUrl));
+            commitId.NotNullOrWhiteSpace(nameof(commitId));
+
+            return FileLinkSettings.AzureDevOpsCommit(repositoryUrl, commitId, rootPath);
         }
     }
 }

--- a/src/Cake.Issues/FileLinkSettings.cs
+++ b/src/Cake.Issues/FileLinkSettings.cs
@@ -28,7 +28,7 @@
         public string FileLinkPattern { get; }
 
         /// <summary>
-        /// Returns settings for linking to files hosted in GitHub.
+        /// Returns settings for linking to files hosted in GitHub on a specific branch.
         /// </summary>
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// eg. <code>https://github.com/cake-contrib/Cake.Issues</code>.</param>
@@ -36,7 +36,7 @@
         /// <param name="rootPath">Root path of the files.
         /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
         /// <returns>Settings for linking to files hosted in GitHub.</returns>
-        public static FileLinkSettings GitHub(
+        public static FileLinkSettings GitHubBranch(
             Uri repositoryUrl,
             string branch,
             string rootPath)
@@ -50,7 +50,29 @@
         }
 
         /// <summary>
-        /// Returns settings for linking to files hosted in Azure DevOps.
+        /// Returns settings for linking to files hosted in GitHub for a specific commit.
+        /// </summary>
+        /// <param name="repositoryUrl">Full URL of the Git repository,
+        /// eg. <code>https://github.com/cake-contrib/Cake.Issues</code>.</param>
+        /// <param name="commitId">The commit id on which the file linking will be based on.</param>
+        /// <param name="rootPath">Root path of the files.
+        /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
+        /// <returns>Settings for linking to files hosted in GitHub.</returns>
+        public static FileLinkSettings GitHubCommit(
+            Uri repositoryUrl,
+            string commitId,
+            string rootPath)
+        {
+            repositoryUrl.NotNull(nameof(repositoryUrl));
+            commitId.NotNullOrWhiteSpace(nameof(commitId));
+
+            return
+                new FileLinkSettings(
+                    repositoryUrl.Append("blob", commitId, rootPath, "{FilePath}#L{Line}").ToString());
+        }
+
+        /// <summary>
+        /// Returns settings for linking to files hosted in Azure DevOps on a specific branch.
         /// </summary>
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// e.g. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
@@ -58,7 +80,7 @@
         /// <param name="rootPath">Root path of the files.
         /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
         /// <returns>Settings for linking to files hosted in Azure DevOps.</returns>
-        public static FileLinkSettings AzureDevOps(
+        public static FileLinkSettings AzureDevOpsBranch(
             Uri repositoryUrl,
             string branch,
             string rootPath)
@@ -76,6 +98,39 @@
                     repositoryUrl.ToString().TrimEnd('/') +
                     "?path=" + rootPath + "{FilePath}" +
                     "&version=GB" + branch +
+                    "&line={Line}" +
+                    "&lineEnd={EndLine}" +
+                    "&lineStartColumn={Column}" +
+                    "&lineEndColumn={EndColumn}");
+        }
+
+        /// <summary>
+        /// Returns settings for linking to files hosted in Azure DevOps for a specific commit id.
+        /// </summary>
+        /// <param name="repositoryUrl">Full URL of the Git repository,
+        /// e.g. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
+        /// <param name="commitId">The commit id on which the file linking will be based on.</param>
+        /// <param name="rootPath">Root path of the files.
+        /// <c>null</c> or <see cref="string.Empty"/> if files are in the root of the repository.</param>
+        /// <returns>Settings for linking to files hosted in Azure DevOps.</returns>
+        public static FileLinkSettings AzureDevOpsCommit(
+            Uri repositoryUrl,
+            string commitId,
+            string rootPath)
+        {
+            repositoryUrl.NotNull(nameof(repositoryUrl));
+            commitId.NotNullOrWhiteSpace(nameof(commitId));
+
+            if (!string.IsNullOrWhiteSpace(rootPath))
+            {
+                rootPath = rootPath.Trim('/') + "/";
+            }
+
+            return
+                new FileLinkSettings(
+                    repositoryUrl.ToString().TrimEnd('/') +
+                    "?path=" + rootPath + "{FilePath}" +
+                    "&version=GC" + commitId +
                     "&line={Line}" +
                     "&lineEnd={EndLine}" +
                     "&lineStartColumn={Column}" +


### PR DESCRIPTION
**What I have done:**

- I created two new classes Branch and Commit, that hold the relevant information now.
- I added new overloads to the `FileLinkSettings` and `Aliases.FileLinking` to allow to pass a commit instead of a branch when linking files in an Azure DevOps enviroment. The existing methods now get a branch-object instead of a string.