### PR TITLE
Make FileLinkSettings builder public.

### DIFF
--- a/src/Cake.Issues/FileLinkSettings.cs
+++ b/src/Cake.Issues/FileLinkSettings.cs
@@ -23,26 +23,13 @@
         }
 
         /// <summary>
-        /// Returns the URL to the file on the source code hosting system
-        /// for the issue <paramref name="issue"/>.
-        /// </summary>
-        /// <param name="issue">Issue for which the link should be returned.</param>
-        /// <returns>URL to the file on the source code hosting system.</returns>
-        public Uri GetFileLink(IIssue issue)
-        {
-            issue.NotNull(nameof(issue));
-
-            return this.builder(issue, new Dictionary<string, string>());
-        }
-
-        /// <summary>
         /// Returns settings to link files based on a custom pattern.
         /// </summary>
         /// <param name="pattern">Pattern of the file link.
         /// See <see cref="IIssueExtensions.ReplaceIssuePattern(string, IIssue)"/>
         /// for a list of tokens supported in the pattern.</param>
         /// <returns>File link settings.</returns>
-        internal static FileLinkSettings ForPattern(string pattern)
+        public static FileLinkSettings ForPattern(string pattern)
         {
             pattern.NotNullOrWhiteSpace(nameof(pattern));
 
@@ -59,7 +46,7 @@
         /// </summary>
         /// <param name="builder">Callback called for building the file link.</param>
         /// <returns>File link settings.</returns>
-        internal static FileLinkSettings ForAction(Func<IIssue, Uri> builder)
+        public static FileLinkSettings ForAction(Func<IIssue, Uri> builder)
         {
             builder.NotNull(nameof(builder));
 
@@ -72,7 +59,7 @@
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// eg. <code>https://github.com/cake-contrib/Cake.Issues</code>.</param>
         /// <returns>Builder class for the settings.</returns>
-        internal static GitHubFileLinkSettingsBuilder ForGitHub(Uri repositoryUrl)
+        public static GitHubFileLinkSettingsBuilder ForGitHub(Uri repositoryUrl)
         {
             repositoryUrl.NotNull(nameof(repositoryUrl));
 
@@ -85,11 +72,24 @@
         /// <param name="repositoryUrl">Full URL of the Git repository,
         /// e.g. <code>https://dev.azure.com/myorganization/_git/myrepo</code>.</param>
         /// <returns>Builder class for the settings.</returns>
-        internal static AzureDevOpsFileLinkSettingsBuilder ForAzureDevOps(Uri repositoryUrl)
+        public static AzureDevOpsFileLinkSettingsBuilder ForAzureDevOps(Uri repositoryUrl)
         {
             repositoryUrl.NotNull(nameof(repositoryUrl));
 
             return new AzureDevOpsFileLinkSettingsBuilder(repositoryUrl);
+        }
+
+        /// <summary>
+        /// Returns the URL to the file on the source code hosting system
+        /// for the issue <paramref name="issue"/>.
+        /// </summary>
+        /// <param name="issue">Issue for which the link should be returned.</param>
+        /// <returns>URL to the file on the source code hosting system.</returns>
+        public Uri GetFileLink(IIssue issue)
+        {
+            issue.NotNull(nameof(issue));
+
+            return this.builder(issue, new Dictionary<string, string>());
         }
     }
 }

--- a/src/Cake.Issues/FileLinking/AzureDevOpsFileLinkSettingsBuilder.cs
+++ b/src/Cake.Issues/FileLinking/AzureDevOpsFileLinkSettingsBuilder.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Class for building settings for file links of files hosted on Azure DevOps.
     /// </summary>
-    internal class AzureDevOpsFileLinkSettingsBuilder
+    public class AzureDevOpsFileLinkSettingsBuilder
     {
         private readonly Uri repositoryUrl;
 

--- a/src/Cake.Issues/FileLinking/FileLinkOptionalSettingsBuilder.cs
+++ b/src/Cake.Issues/FileLinking/FileLinkOptionalSettingsBuilder.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// Class containing builder for optional settings for linking to files.
     /// </summary>
-    internal class FileLinkOptionalSettingsBuilder : FileLinkSettings
+    public class FileLinkOptionalSettingsBuilder : FileLinkSettings
     {
         private readonly Func<IIssue, IDictionary<string, string>, Uri> builder;
 

--- a/src/Cake.Issues/FileLinking/GitHubFileLinkSettingsBuilder.cs
+++ b/src/Cake.Issues/FileLinking/GitHubFileLinkSettingsBuilder.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Class for building settings for file links of files hosted on GitHub.
     /// </summary>
-    internal class GitHubFileLinkSettingsBuilder
+    public class GitHubFileLinkSettingsBuilder
     {
         private readonly Uri repositoryUrl;
 


### PR DESCRIPTION
There are use cases where direct access to FileLinkSettings would be helpful (e.g. for test cases in addins).