### PR TITLE
Added WithFileLinkSettings to the IssueBuilder

### DIFF
--- a/src/Cake.Issues.Tests/IssueBuilderTests.cs
+++ b/src/Cake.Issues.Tests/IssueBuilderTests.cs
@@ -1636,6 +1636,67 @@
             }
         }
 
+        public sealed class TheWithFileLinkSettingsMethod
+        {
+            [Fact]
+            public void Should_Throw_If_FileLinkSettings_Are_Null()
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+                FileLinkSettings fileLinkSettings = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    fixture.IssueBuilder.WithFileLinkSettings(fileLinkSettings));
+
+                // Then
+                result.IsArgumentNullException("fileLinkSettings");
+            }
+
+
+            [Fact]
+            public void Should_Resolve_FileLink_When_FileLinkSettings_Were_Provided()
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+                var fileLinkSettings =
+                    FileLinkSettings
+                        .ForAzureDevOps(new Uri("https://test.com/tfs/myrepo"))
+                        .Branch("dev");
+
+                // When
+                var issue = 
+                    fixture.IssueBuilder
+                        .InFile("fooPath", 10, 20, 1, 10)
+                        .WithFileLinkSettings(fileLinkSettings).Create();
+
+                // Then
+                issue.FileLink.ShouldBe(new Uri("https://test.com/tfs/myrepo?path=/fooPath&version=GBdev&line=10&lineEnd=20&lineStartColumn=1&lineEndColumn=10"));
+            }
+
+            [Fact]
+            public void Should_Use_FileLink_When_Both_FileLink_And_FileLinkSettings_Were_Provided()
+            {
+                // Given
+                var fixture = new IssueBuilderFixture();
+                var fileLinkSettings =
+                    FileLinkSettings
+                        .ForAzureDevOps(new Uri("https://test.com/tfs/myrepo"))
+                        .Branch("dev");
+
+                // When
+                var issue =
+                    fixture.IssueBuilder
+                        .InFile("fooPath", 10, 20, 1, 10)
+                        .WithFileLink(new Uri("https://this-will-win.com/"))
+                        .WithFileLinkSettings(fileLinkSettings)
+                        .Create();
+
+                // Then
+                issue.FileLink.ShouldBe(new Uri("https://this-will-win.com/"));
+            }
+        }
+
         public sealed class TheWithPriorityMethod
         {
             [Fact]

--- a/src/Cake.Issues/IssueBuilder.cs
+++ b/src/Cake.Issues/IssueBuilder.cs
@@ -26,6 +26,7 @@
         private string rule;
         private Uri ruleUrl;
         private string run;
+        private FileLinkSettings fileLinkSettings;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IssueBuilder"/> class.
@@ -320,6 +321,20 @@
         }
 
         /// <summary>
+        /// Sets a <see cref="FileLinkSettings"/> to create the link of the position in the file where the issue ocurred.
+        /// </summary>
+        /// <param name="fileLinkSettings">Settings to create the link of the position in the file where the issue ocurred.</param>
+        /// <returns>Issue Builder instance.</returns>
+        public IssueBuilder WithFileLinkSettings(FileLinkSettings fileLinkSettings)
+        {
+            fileLinkSettings.NotNull(nameof(fileLinkSettings));
+
+            this.fileLinkSettings = fileLinkSettings;
+
+            return this;
+        }
+
+        /// <summary>
         /// Sets the priority of the issue.
         /// </summary>
         /// <param name="priority">The priority of the issue.</param>
@@ -394,27 +409,39 @@
         /// <returns>New issue object.</returns>
         public IIssue Create()
         {
-            return
-                new Issue(
-                    this.identifier,
-                    this.projectFileRelativePath,
-                    this.projectName,
-                    this.filePath,
-                    this.line,
-                    this.endLine,
-                    this.column,
-                    this.endColumn,
-                    this.fileLink,
-                    this.messageText,
-                    this.messageHtml,
-                    this.messageMarkdown,
-                    this.priority,
-                    this.priorityName,
-                    this.rule,
-                    this.ruleUrl,
-                    this.run,
-                    this.providerType,
-                    this.providerName);
+            var issue = this.CreateIssue(this.fileLink);
+
+            if (this.fileLink != null || this.fileLinkSettings == null)
+            {
+                return issue;
+            }
+
+            // Recreate the issue here to pass the resolved file link this time.
+            return this.CreateIssue(this.fileLinkSettings.GetFileLink(issue));
+        }
+
+        private Issue CreateIssue(Uri fileLink)
+        {
+            return new Issue(
+                this.identifier,
+                this.projectFileRelativePath,
+                this.projectName,
+                this.filePath,
+                this.line,
+                this.endLine,
+                this.column,
+                this.endColumn,
+                fileLink,
+                this.messageText,
+                this.messageHtml,
+                this.messageMarkdown,
+                this.priority,
+                this.priorityName,
+                this.rule,
+                this.ruleUrl,
+                this.run,
+                this.providerType,
+                this.providerName);
         }
     }
 }


### PR DESCRIPTION
Added a `WithFileLinkSettings()` method to the `IssueBuilder`.
During `IssueBuilder.Create()` we do resolve the file link and recreate an issue, when the FileLinkSettings are provided.

`WithFileLink()` is priorized over `WithFileLinkSettings()`.

Resolves #212 