### PR TITLE
Disable publishing to GitHub package repository

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,8 @@
+environment:
+  # Disable publishing to GitHub package repository, since it will fail for
+  # Cake.Issues.Reporting and Cake.Issues.PullRequests because an archived repo with that name exists.
+  GPR_SOURCE:
+
 #---------------------------------#
 #  Build Image                    #
 #---------------------------------#


### PR DESCRIPTION
Disable publishing to GitHub package repository, since it will fail for Cake.Issues.Reporting and Cake.Issues.PullRequests because an archived repo with that name exists.