### PR TITLE
(GH-264) Multi-Target .NET Core 3.1, 5, & 6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ environment:
 #---------------------------------#
 #  Build Image                    #
 #---------------------------------#
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 #---------------------------------#
 #  Build Script                   #

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:
 jobs:
 - job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   steps:
   - powershell: ./build.ps1
     displayName: 'Cake Build'

--- a/nuspec/nuget/Cake.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.nuspec
@@ -26,8 +26,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.PullRequests.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.PullRequests.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.PullRequests.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.nuspec
@@ -26,8 +26,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.Reporting.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.Reporting.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.Reporting.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.Reporting.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.Reporting.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.Reporting.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.Reporting.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.Reporting.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.Reporting.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.Reporting.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.Reporting.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.Reporting.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Testing.nuspec
+++ b/nuspec/nuget/Cake.Issues.Testing.nuspec
@@ -21,8 +21,14 @@ Common helpers for testing add-ins based on Cake.Issues
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.Testing.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.Testing.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.Testing.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.Testing.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.Testing.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.Testing.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.Testing.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.Testing.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.Testing.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.Testing.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.Testing.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.Testing.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.nuspec
+++ b/nuspec/nuget/Cake.Issues.nuspec
@@ -28,8 +28,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/recipe.cake
+++ b/recipe.cake
@@ -27,4 +27,8 @@ ToolSettings.SetToolSettings(
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 
+// Workaround until https://github.com/cake-contrib/Cake.Recipe/issues/862 has been fixed in Cake.Recipe
+ToolSettings.SetToolPreprocessorDirectives(
+    reSharperTools: "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2021.2.0");
+
 Build.RunDotNetCore();

--- a/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -10,19 +10,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.PullRequests.xml</DocumentationFile>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.PullRequests.xml</DocumentationFile>
   </PropertyGroup>
 
    <ItemGroup>

--- a/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>
     <Description>Tests for the Cake.Issues.Reporting addin</Description>

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Addin for the Cake build automation system for creating reports for issues from any code analyzer or linter</Description>
     <Authors>BBT Software AG and contributors</Authors>
     <Company>BBT Software AG and contributors</Company>

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -10,19 +10,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.Reporting.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.Reporting.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
+++ b/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
@@ -10,18 +10,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Testing.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.Testing.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.Testing.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
+++ b/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Common helpers for testing addins based on Cake.Issues</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>

--- a/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
+++ b/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Addin for reading code analyzer or linter issues for the Cake build automation system</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -9,18 +9,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.xml</DocumentationFile>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #264 