### PR TITLE
(GH-255) Rename ProviderIssueIssueLimits to ProviderIssueLimits

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/IssueFiltererTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IssueFiltererTests.cs
@@ -484,7 +484,7 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderType Foo",
-                            new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 2));
+                            new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 2));
 
                         var newIssue1 =
                             IssueBuilder
@@ -557,7 +557,7 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderType Foo",
-                            new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 0));
+                            new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 0));
 
                         var newIssue1 =
                             IssueBuilder
@@ -630,7 +630,7 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderType Foo",
-                            new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: -3));
+                            new ProviderIssueLimits(maxIssuesToPostAcrossRuns: -3));
 
                         var newIssue1 =
                             IssueBuilder
@@ -703,7 +703,7 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderType Foo",
-                            new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 2));
+                            new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 2));
 
                         var issue1 =
                             IssueBuilder
@@ -769,7 +769,7 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderType Foo",
-                            new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 2));
+                            new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 2));
 
                         var issue1 =
                             IssueBuilder
@@ -846,10 +846,10 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeA",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeB",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
 
                         var issue1 =
                             IssueBuilder
@@ -905,10 +905,10 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeA",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 0));
+                            new ProviderIssueLimits(maxIssuesToPost: 0));
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeB",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 0));
+                            new ProviderIssueLimits(maxIssuesToPost: 0));
 
                         var issue1 =
                             IssueBuilder
@@ -962,10 +962,10 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeA",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: -3));
+                            new ProviderIssueLimits(maxIssuesToPost: -3));
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeB",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: -1));
+                            new ProviderIssueLimits(maxIssuesToPost: -1));
 
                         var issue1 =
                             IssueBuilder
@@ -1020,10 +1020,10 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeA",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeB",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
 
                         var issue1 =
                             IssueBuilder
@@ -1078,10 +1078,10 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeA",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeB",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
 
                         var issue1 =
                             IssueBuilder
@@ -1134,10 +1134,10 @@
                         var fixture = new IssueFiltererFixture();
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeA",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                            new ProviderIssueLimits(maxIssuesToPost: 1));
                         fixture.Settings.ProviderIssueLimits.Add(
                             "ProviderTypeB",
-                            new ProviderIssueIssueLimits(maxIssuesToPost: 3));
+                            new ProviderIssueLimits(maxIssuesToPost: 3));
 
                         var issue1 =
                             IssueBuilder

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -688,7 +688,7 @@ namespace Cake.Issues.PullRequests.Tests
             }
 
             [Fact]
-            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_ProviderIssueIssueLimits()
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_ProviderIssueLimits()
             {
                 // Given
                 var issue1 =
@@ -733,10 +733,10 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeA",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeB",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -752,7 +752,7 @@ namespace Cake.Issues.PullRequests.Tests
             }
 
             [Fact]
-            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_By_Priority_ProviderIssueIssueLimits()
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_By_Priority_ProviderIssueLimits()
             {
                 // Given
                 var issue1 =
@@ -797,10 +797,10 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeA",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeB",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -816,7 +816,7 @@ namespace Cake.Issues.PullRequests.Tests
             }
 
             [Fact]
-            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_By_FilePath_ProviderIssueIssueLimits()
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_By_FilePath_ProviderIssueLimits()
             {
                 // Given
                 var issue1 =
@@ -859,10 +859,10 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeA",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeB",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -878,7 +878,7 @@ namespace Cake.Issues.PullRequests.Tests
             }
 
             [Fact]
-            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_With_Different_Limits_For_Each_ProviderProviderIssueIssueLimits()
+            public void Should_Limit_Messages_To_Maximum_Per_Issue_Provider_With_Different_Limits_For_Each_ProviderIssueLimits()
             {
                 // Given
                 var issue1 =
@@ -958,10 +958,10 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeA",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 1));
+                    new ProviderIssueLimits(maxIssuesToPost: 1));
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderTypeB",
-                    new ProviderIssueIssueLimits(maxIssuesToPost: 3));
+                    new ProviderIssueLimits(maxIssuesToPost: 3));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -1422,7 +1422,7 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderType Foo",
-                    new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 1));
+                    new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 1));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -1471,7 +1471,7 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderType Foo",
-                    new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 1));
+                    new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 1));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -1528,7 +1528,7 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderType Foo",
-                    new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 1));
+                    new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 1));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -1619,7 +1619,7 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderType Foo",
-                    new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 2));
+                    new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 2));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -1690,7 +1690,7 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderType Foo",
-                    new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 2));
+                    new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 2));
 
                 // When
                 var result = fixture.RunOrchestrator();
@@ -1757,7 +1757,7 @@ namespace Cake.Issues.PullRequests.Tests
 
                 fixture.Settings.ProviderIssueLimits.Add(
                     "ProviderType Foo",
-                    new ProviderIssueIssueLimits(maxIssuesToPostAcrossRuns: 2));
+                    new ProviderIssueLimits(maxIssuesToPostAcrossRuns: 2));
 
                 // When
                 var result = fixture.RunOrchestrator();

--- a/src/Cake.Issues.PullRequests/ProviderIssueLimits.cs
+++ b/src/Cake.Issues.PullRequests/ProviderIssueLimits.cs
@@ -1,14 +1,14 @@
 ﻿namespace Cake.Issues.PullRequests
 {
     /// <inheritdoc />
-    public class ProviderIssueIssueLimits : IProviderIssueLimits
+    public class ProviderIssueLimits : IProviderIssueLimits
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ProviderIssueIssueLimits"/> class.
+        /// Initializes a new instance of the <see cref="ProviderIssueLimits"/> class.
         /// </summary>
         /// <param name="maxIssuesToPost">Maximum amount of issues to be posted in a single run.</param>
         /// <param name="maxIssuesToPostAcrossRuns">Maximum amount of issues to be posted across all runs.</param>
-        public ProviderIssueIssueLimits(
+        public ProviderIssueLimits(
             int? maxIssuesToPost = null,
             int? maxIssuesToPostAcrossRuns = null)
         {


### PR DESCRIPTION
Fixes a typo in `ProviderIssueIssueLimits` class

Fixes #255  