### PR TITLE
Update Depandabot configuration to ignore Cake updates < 3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   ignore:
   - dependency-name: Cake.Core
     versions:
-    - "> 1.0.0, < 2"
+    - "(,3.0)"
   - dependency-name: Cake.Testing
     versions:
-    - "> 1.0.0, < 2"
+    - "(,3.0)"


### PR DESCRIPTION
Update Depandabot configuration to ignore all Cake updates until 3.0