### PR TITLE
(GH-303) Update target frameworks

### DIFF
--- a/nuspec/nuget/Cake.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.nuspec
@@ -26,14 +26,11 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1\Cake.Issues.PullRequests.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.PullRequests.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.PullRequests.xml" target="lib\netcoreapp3.1" />
-    <file src="net5.0\Cake.Issues.PullRequests.dll" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.PullRequests.pdb" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.PullRequests.xml" target="lib\net5.0" />
     <file src="net6.0\Cake.Issues.PullRequests.dll" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.PullRequests.pdb" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.PullRequests.xml" target="lib\net6.0" />
+    <file src="net7.0\Cake.Issues.PullRequests.dll" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.PullRequests.pdb" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.PullRequests.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.nuspec
@@ -26,14 +26,11 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1\Cake.Issues.Reporting.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.Reporting.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.Reporting.xml" target="lib\netcoreapp3.1" />
-    <file src="net5.0\Cake.Issues.Reporting.dll" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.Reporting.pdb" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.Reporting.xml" target="lib\net5.0" />
     <file src="net6.0\Cake.Issues.Reporting.dll" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.Reporting.pdb" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.Reporting.xml" target="lib\net6.0" />
+    <file src="net7.0\Cake.Issues.Reporting.dll" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.Reporting.pdb" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.Reporting.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Testing.nuspec
+++ b/nuspec/nuget/Cake.Issues.Testing.nuspec
@@ -21,14 +21,11 @@ Common helpers for testing add-ins based on Cake.Issues
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1\Cake.Issues.Testing.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.Testing.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.Testing.xml" target="lib\netcoreapp3.1" />
-    <file src="net5.0\Cake.Issues.Testing.dll" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.Testing.pdb" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.Testing.xml" target="lib\net5.0" />
     <file src="net6.0\Cake.Issues.Testing.dll" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.Testing.pdb" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.Testing.xml" target="lib\net6.0" />
+    <file src="net7.0\Cake.Issues.Testing.dll" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.Testing.pdb" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.Testing.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.nuspec
+++ b/nuspec/nuget/Cake.Issues.nuspec
@@ -28,14 +28,11 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1\Cake.Issues.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Issues.xml" target="lib\netcoreapp3.1" />
-    <file src="net5.0\Cake.Issues.dll" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.pdb" target="lib\net5.0" />
-    <file src="net5.0\Cake.Issues.xml" target="lib\net5.0" />
     <file src="net6.0\Cake.Issues.dll" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.pdb" target="lib\net6.0" />
     <file src="net6.0\Cake.Issues.xml" target="lib\net6.0" />
+    <file src="net7.0\Cake.Issues.dll" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.pdb" target="lib\net7.0" />
+    <file src="net7.0\Cake.Issues.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>
     <Description>Tests for the Cake.Issues.Reporting addin</Description>

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>Addin for the Cake build automation system for creating reports for issues from any code analyzer or linter</Description>
     <Authors>BBT Software AG and contributors</Authors>
     <Company>BBT Software AG and contributors</Company>

--- a/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
+++ b/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>Common helpers for testing addins based on Cake.Issues</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>

--- a/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
+++ b/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © BBT Software AG and contributors</Copyright>

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <Description>Addin for reading code analyzer or linter issues for the Cake build automation system</Description>
     <Authors>BBT Software AG</Authors>
     <Company>BBT Software AG</Company>


### PR DESCRIPTION
Remove support for .NET Core 3.1 and .NET 5. Add support for .NET 7

Fixes #303 