### PR TITLE
Make constructors of abstract classes protected

### DIFF
--- a/src/Cake.Issues.PullRequests/BaseCheckingCommitIdCapability.cs
+++ b/src/Cake.Issues.PullRequests/BaseCheckingCommitIdCapability.cs
@@ -15,7 +15,7 @@
         /// </summary>
         /// <param name="log">The Cake log context.</param>
         /// <param name="pullRequestSystem">Pull request system to which this capability belongs.</param>
-        public BaseCheckingCommitIdCapability(ICakeLog log, T pullRequestSystem)
+        protected BaseCheckingCommitIdCapability(ICakeLog log, T pullRequestSystem)
             : base(log, pullRequestSystem)
         {
         }

--- a/src/Cake.Issues.PullRequests/BaseDiscussionThreadsCapability.cs
+++ b/src/Cake.Issues.PullRequests/BaseDiscussionThreadsCapability.cs
@@ -16,7 +16,7 @@
         /// </summary>
         /// <param name="log">The Cake log context.</param>
         /// <param name="pullRequestSystem">Pull request system to which this capability belongs.</param>
-        public BaseDiscussionThreadsCapability(ICakeLog log, T pullRequestSystem)
+        protected BaseDiscussionThreadsCapability(ICakeLog log, T pullRequestSystem)
             : base(log, pullRequestSystem)
         {
         }

--- a/src/Cake.Issues.PullRequests/BaseFilteringByModifiedFilesCapability.cs
+++ b/src/Cake.Issues.PullRequests/BaseFilteringByModifiedFilesCapability.cs
@@ -17,7 +17,7 @@
         /// </summary>
         /// <param name="log">The Cake log context.</param>
         /// <param name="pullRequestSystem">Pull request system to which this capability belongs.</param>
-        public BaseFilteringByModifiedFilesCapability(ICakeLog log, T pullRequestSystem)
+        protected BaseFilteringByModifiedFilesCapability(ICakeLog log, T pullRequestSystem)
             : base(log, pullRequestSystem)
         {
         }

--- a/src/Cake.Issues.PullRequests/BasePullRequestSystemCapability.cs
+++ b/src/Cake.Issues.PullRequests/BasePullRequestSystemCapability.cs
@@ -14,7 +14,7 @@
         /// </summary>
         /// <param name="log">The Cake log context.</param>
         /// <param name="pullRequestSystem">Pull request system to which this capability belongs.</param>
-        public BasePullRequestSystemCapability(ICakeLog log, T pullRequestSystem)
+        protected BasePullRequestSystemCapability(ICakeLog log, T pullRequestSystem)
         {
             log.NotNull(nameof(log));
             pullRequestSystem.NotNull(nameof(pullRequestSystem));

--- a/src/Cake.Issues.Testing/BaseMultiFormatIssueProviderFixture.cs
+++ b/src/Cake.Issues.Testing/BaseMultiFormatIssueProviderFixture.cs
@@ -19,7 +19,7 @@
         /// Initializes a new instance of the <see cref="BaseMultiFormatIssueProviderFixture{TIssueProvider, TSettings, TLogFileFormat}"/> class.
         /// </summary>
         /// <param name="fileResourceName">Name of the resource to load.</param>
-        public BaseMultiFormatIssueProviderFixture(string fileResourceName)
+        protected BaseMultiFormatIssueProviderFixture(string fileResourceName)
             : base(fileResourceName)
         {
         }

--- a/src/Cake.Issues/BaseMultiFormatIssueProviderSettings.cs
+++ b/src/Cake.Issues/BaseMultiFormatIssueProviderSettings.cs
@@ -18,7 +18,7 @@
         /// <param name="logFilePath">Path to the log file.
         /// The log file needs to be in the format as defined by the <paramref name="format"/> parameter.</param>
         /// <param name="format">Format of the provided log file.</param>
-        public BaseMultiFormatIssueProviderSettings(FilePath logFilePath, ILogFileFormat<TIssueProvider, TSettings> format)
+        protected BaseMultiFormatIssueProviderSettings(FilePath logFilePath, ILogFileFormat<TIssueProvider, TSettings> format)
             : base(logFilePath)
         {
             format.NotNull(nameof(format));
@@ -33,7 +33,7 @@
         /// <param name="logFileContent">Content of the log file.
         /// The log file needs to be in the format as defined by the <paramref name="format"/> parameter.</param>
         /// <param name="format">Format of the provided log file.</param>
-        public BaseMultiFormatIssueProviderSettings(byte[] logFileContent, ILogFileFormat<TIssueProvider, TSettings> format)
+        protected BaseMultiFormatIssueProviderSettings(byte[] logFileContent, ILogFileFormat<TIssueProvider, TSettings> format)
             : base(logFileContent)
         {
             format.NotNull(nameof(format));


### PR DESCRIPTION
Having constructors of abstract classes makes no sense since they can't be instantiated. This PR changes visibility of them to protected.