### PR TITLE
Remove dupFinder exclusions

### DIFF
--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -27,10 +27,6 @@ namespace Cake.Issues.PullRequests
             IPullRequestSystem pullRequestSystem,
             IReportIssuesToPullRequestSettings settings)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             log.NotNull(nameof(log));
             pullRequestSystem.NotNull(nameof(pullRequestSystem));
             settings.NotNull(nameof(settings));
@@ -38,8 +34,6 @@ namespace Cake.Issues.PullRequests
             this.log = log;
             this.pullRequestSystem = pullRequestSystem;
             this.settings = settings;
-
-            #endregion
         }
 
         /// <summary>

--- a/src/Cake.Issues.PullRequests/Orchestrator.cs
+++ b/src/Cake.Issues.PullRequests/Orchestrator.cs
@@ -25,17 +25,11 @@ namespace Cake.Issues.PullRequests
             ICakeLog log,
             IPullRequestSystem pullRequestSystem)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             log.NotNull(nameof(log));
             pullRequestSystem.NotNull(nameof(pullRequestSystem));
 
             this.log = log;
             this.pullRequestSystem = pullRequestSystem;
-
-            #endregion
         }
 
         /// <summary>

--- a/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestFromIssueProviderSettings.cs
+++ b/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestFromIssueProviderSettings.cs
@@ -9,11 +9,7 @@
     /// </summary>
     public class ReportIssuesToPullRequestFromIssueProviderSettings : ReadIssuesSettings, IReportIssuesToPullRequestFromIssueProviderSettings
     {
-#pragma warning disable SA1124 // Do not use regions
-        #region DupFinder Exclusion
-#pragma warning restore SA1124 // Do not use regions
         private readonly List<Func<IEnumerable<IIssue>, IEnumerable<IIssue>>> issueFilters = new ();
-        #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReportIssuesToPullRequestFromIssueProviderSettings"/> class.

--- a/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
+++ b/src/Cake.Issues.PullRequests/ReportIssuesToPullRequestSettings.cs
@@ -9,11 +9,7 @@
     /// </summary>
     public class ReportIssuesToPullRequestSettings : RepositorySettings, IReportIssuesToPullRequestSettings
     {
-#pragma warning disable SA1124 // Do not use regions
-        #region DupFinder Exclusion
-#pragma warning restore SA1124 // Do not use regions
         private readonly List<Func<IEnumerable<IIssue>, IEnumerable<IIssue>>> issueFilters = new ();
-        #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReportIssuesToPullRequestSettings"/> class.

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
@@ -13,10 +13,6 @@
             [Fact]
             public void Should_Throw_If_IssueToCheck_Is_Null()
             {
-#pragma warning disable SA1123 // Do not place regions within elements
-                #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
                 // Given
                 var fixture = new IssueBuilderFixture();
                 IIssue issueToCheck = null;
@@ -28,17 +24,11 @@
 
                 // Then
                 result.IsArgumentNullException("issueToCheck");
-
-                #endregion
             }
 
             [Fact]
             public void Should_Throw_If_ExpectedIssue_Is_Null()
             {
-#pragma warning disable SA1123 // Do not place regions within elements
-                #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
                 // Given
                 var fixture = new IssueBuilderFixture();
                 var issueToCheck = fixture.IssueBuilder.Create();
@@ -50,8 +40,6 @@
 
                 // Then
                 result.IsArgumentNullException("expectedIssue");
-
-                #endregion
             }
 
             [Fact]
@@ -74,10 +62,6 @@
             [Fact]
             public void Should_Throw_If_IssueToCheck_Is_Null()
             {
-#pragma warning disable SA1123 // Do not place regions within elements
-                #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
                 // Given
                 var fixture = new IssueBuilderFixture();
                 IIssue issueToCheck = null;
@@ -89,17 +73,11 @@
 
                 // Then
                 result.IsArgumentNullException("issueToCheck");
-
-                #endregion
             }
 
             [Fact]
             public void Should_Throw_If_ExpectedIssue_Is_Null()
             {
-#pragma warning disable SA1123 // Do not place regions within elements
-                #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
                 // Given
                 var fixture = new IssueBuilderFixture();
                 var issueToCheck = fixture.IssueBuilder.Create();
@@ -111,8 +89,6 @@
 
                 // Then
                 result.IsArgumentNullException("expectedIssue");
-
-                #endregion
             }
 
             [Fact]

--- a/src/Cake.Issues/Aliases.NewIssue.cs
+++ b/src/Cake.Issues/Aliases.NewIssue.cs
@@ -81,17 +81,11 @@
             string providerType,
             string providerName)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             context.NotNull(nameof(context));
             identifier.NotNullOrWhiteSpace(nameof(identifier));
             message.NotNullOrWhiteSpace(nameof(message));
             providerType.NotNullOrWhiteSpace(nameof(providerType));
             providerName.NotNullOrWhiteSpace(nameof(providerName));
-
-            #endregion
 
             return IssueBuilder.NewIssue(identifier, message, providerType, providerName);
         }

--- a/src/Cake.Issues/IssueBuilder.cs
+++ b/src/Cake.Issues/IssueBuilder.cs
@@ -44,16 +44,10 @@
             string providerType,
             string providerName)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             identifier.NotNullOrWhiteSpace(nameof(identifier));
             message.NotNullOrWhiteSpace(nameof(message));
             providerType.NotNullOrWhiteSpace(nameof(providerType));
             providerName.NotNullOrWhiteSpace(nameof(providerName));
-
-            #endregion
 
             this.identifier = identifier;
             this.messageText = message;
@@ -141,16 +135,10 @@
             string providerType,
             string providerName)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             identifier.NotNullOrWhiteSpace(nameof(identifier));
             message.NotNullOrWhiteSpace(nameof(message));
             providerType.NotNullOrWhiteSpace(nameof(providerType));
             providerName.NotNullOrWhiteSpace(nameof(providerName));
-
-            #endregion
 
             return new IssueBuilder(identifier, message, providerType, providerName);
         }

--- a/src/Cake.Issues/Serialization/SerializableIssueExtensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueExtensions.cs
@@ -15,10 +15,6 @@
         /// <returns>Converted issue.</returns>
         internal static Issue ToIssue(this SerializableIssue serializableIssue)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             serializableIssue.NotNull(nameof(serializableIssue));
 
             Uri ruleUrl = null;
@@ -49,8 +45,6 @@
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName,
                 new Dictionary<string, string>());
-
-            #endregion
         }
     }
 }

--- a/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV2Extensions.cs
@@ -15,10 +15,6 @@
         /// <returns>Converted issue.</returns>
         internal static Issue ToIssue(this SerializableIssueV2 serializableIssue)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             serializableIssue.NotNull(nameof(serializableIssue));
 
             Uri ruleUrl = null;
@@ -49,8 +45,6 @@
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName,
                 new Dictionary<string, string>());
-
-            #endregion
         }
     }
 }

--- a/src/Cake.Issues/Serialization/SerializableIssueV3Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV3Extensions.cs
@@ -15,10 +15,6 @@
         /// <returns>Converted issue.</returns>
         internal static Issue ToIssue(this SerializableIssueV3 serializableIssue)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             serializableIssue.NotNull(nameof(serializableIssue));
 
             Uri ruleUrl = null;
@@ -55,8 +51,6 @@
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName,
                 new Dictionary<string, string>());
-
-            #endregion
         }
     }
 }

--- a/src/Cake.Issues/Serialization/SerializableIssueV4Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV4Extensions.cs
@@ -14,10 +14,6 @@
         /// <returns>Converted issue.</returns>
         internal static Issue ToIssue(this SerializableIssueV4 serializableIssue)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             serializableIssue.NotNull(nameof(serializableIssue));
 
             Uri ruleUrl = null;
@@ -54,8 +50,6 @@
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName,
                 serializableIssue.AdditionalInformation);
-
-            #endregion
         }
     }
 }

--- a/src/Cake.Issues/Serialization/SerializableIssueV5Extensions.cs
+++ b/src/Cake.Issues/Serialization/SerializableIssueV5Extensions.cs
@@ -14,10 +14,6 @@
         /// <returns>Converted issue.</returns>
         internal static Issue ToIssue(this SerializableIssueV5 serializableIssue)
         {
-#pragma warning disable SA1123 // Do not place regions within elements
-            #region DupFinder Exclusion
-#pragma warning restore SA1123 // Do not place regions within elements
-
             serializableIssue.NotNull(nameof(serializableIssue));
 
             Uri ruleUrl = null;
@@ -54,8 +50,6 @@
                 serializableIssue.ProviderType,
                 serializableIssue.ProviderName,
                 serializableIssue.AdditionalInformation);
-
-            #endregion
         }
     }
 }


### PR DESCRIPTION
Since we no longer run dupFinder during build, exclusions can be removed from source code