### PR TITLE
Mark assertion methods

### DIFF
--- a/src/Cake.Issues.Testing/AssertionMethodAttribute.cs
+++ b/src/Cake.Issues.Testing/AssertionMethodAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace Cake.Issues.Testing
+{
+    using System;
+
+    /// <summary>
+    /// Attribute for marking custom assertion methods.
+    /// </summary>
+    public class AssertionMethodAttribute : Attribute
+    {
+    }
+}

--- a/src/Cake.Issues.Testing/ExceptionAssertExtensions.cs
+++ b/src/Cake.Issues.Testing/ExceptionAssertExtensions.cs
@@ -12,6 +12,7 @@
         /// </summary>
         /// <param name="exception">Exception to check.</param>
         /// <param name="parameterName">Expected name of the parameter which has caused the exception.</param>
+        [AssertionMethod]
         public static void IsArgumentException(this Exception exception, string parameterName)
         {
             var argumentException = exception.CheckExceptionType<ArgumentException>();
@@ -27,6 +28,7 @@
         /// </summary>
         /// <param name="exception">Exception to check.</param>
         /// <param name="parameterName">Expected name of the parameter which has caused the exception.</param>
+        [AssertionMethod]
         public static void IsArgumentNullException(this Exception exception, string parameterName)
         {
             var argumentNullException = exception.CheckExceptionType<ArgumentNullException>();
@@ -42,6 +44,7 @@
         /// </summary>
         /// <param name="exception">Exception to check.</param>
         /// <param name="parameterName">Expected name of the parameter which has caused the exception.</param>
+        [AssertionMethod]
         public static void IsArgumentOutOfRangeException(this Exception exception, string parameterName)
         {
             var argumentOutOfRangeException = exception.CheckExceptionType<ArgumentOutOfRangeException>();
@@ -57,6 +60,7 @@
         /// </summary>
         /// <param name="exception">Exception to check.</param>
         /// <param name="message">Expected exception message.</param>
+        [AssertionMethod]
         public static void IsInvalidOperationException(this Exception exception, string message)
         {
             var invalidOperationException = exception.CheckExceptionType<InvalidOperationException>();

--- a/src/Cake.Issues.Testing/IssueChecker.cs
+++ b/src/Cake.Issues.Testing/IssueChecker.cs
@@ -15,6 +15,7 @@
         /// </summary>
         /// <param name="issueToCheck">Issue which should be checked.</param>
         /// <param name="expectedIssue">Description of the expected issue.</param>
+        [AssertionMethod]
         public static void Check(
             IIssue issueToCheck,
             IssueBuilder expectedIssue)
@@ -32,6 +33,7 @@
         /// </summary>
         /// <param name="issueToCheck">Issue which should be checked.</param>
         /// <param name="expectedIssue">Description of the expected issue.</param>
+        [AssertionMethod]
         public static void Check(
             IIssue issueToCheck,
             IIssue expectedIssue)
@@ -102,6 +104,7 @@
         /// <param name="ruleUrl">Expected URL containing information about the failing rule.
         /// <c>null</c> if no rule Url is expected.</param>
         /// <param name="additionalInformation">Custom information regarding the issue.</param>
+        [AssertionMethod]
         public static void Check(
             IIssue issue,
             string providerType,


### PR DESCRIPTION
Mark assertion methods through an attribute. This helps to avoid code analysis issues with certain linters (e.g. SonarLint)