### PR TITLE
(GH-322) Make BaseRuleDescription.Rule immutable

### DIFF
--- a/src/Cake.Issues/BaseRuleDescription.cs
+++ b/src/Cake.Issues/BaseRuleDescription.cs
@@ -6,8 +6,8 @@
     public class BaseRuleDescription
     {
         /// <summary>
-        /// Gets or sets the full identifier of the rule.
+        /// Gets the full identifier of the rule.
         /// </summary>
-        public string Rule { get; set; }
+        public string Rule { get; init; }
     }
 }


### PR DESCRIPTION
Ensures that `BaseRuleDescription.Rule` can't be changed after initialization.

Fixes #322 