### PR TITLE
(GH-329) Make BaseRuleDescription abstract

### DIFF
--- a/src/Cake.Issues/BaseRuleDescription.cs
+++ b/src/Cake.Issues/BaseRuleDescription.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Base class for all rule descriptions.
     /// </summary>
-    public class BaseRuleDescription
+    public abstract class BaseRuleDescription
     {
         /// <summary>
         /// Gets the full identifier of the rule.


### PR DESCRIPTION
Make `BaseRuleDescription` abstract

Fixes #329 