### PR TITLE
Update README to follow standard specification

### DIFF
--- a/CiStatus.md
+++ b/CiStatus.md
@@ -1,0 +1,6 @@
+# Build & Test Status
+
+| Type | CI Server | Runner | Operating System | Develop | Master |
+|:--:|:--:|:--:|:--:|:--:|:--:|
+|Build / Unit Tests|AppVeyor|N/A|Windows|[![Build status](https://ci.appveyor.com/api/projects/status/sde2oe3lu4kpmw0r/branch/develop?svg=true)](https://ci.appveyor.com/project/cakecontrib/cake-issues/branch/develop)|[![Build status](https://ci.appveyor.com/api/projects/status/sde2oe3lu4kpmw0r/branch/master?svg=true)](https://ci.appveyor.com/project/cakecontrib/cake-issues/branch/master)|
+|Build / Unit Tests|Azure Pipelines|N/A|Windows|[![Build Status](https://dev.azure.com/cake-contrib/Cake.Issues/_apis/build/status%2Fcake-contrib.Cake.Issues?branchName=develop&jobName=Windows)](https://dev.azure.com/cake-contrib/Cake.Issues/_build/latest?definitionId=2&branchName=develop)|[![Build Status](https://dev.azure.com/cake-contrib/Cake.Issues/_apis/build/status%2Fcake-contrib.Cake.Issues?branchName=master&jobName=Windows)](https://dev.azure.com/cake-contrib/Cake.Issues/_build/latest?definitionId=2&branchName=master)|

--- a/README.md
+++ b/README.md
@@ -1,40 +1,142 @@
 # Cake Issues Addin
 
-This addin for the Cake build automation system allows you to read issues from any code analyzer or linter.
+[![License](https://img.shields.io/:license-mit-blue.svg)](https://github.com/cake-contrib/Cake.Issues/blob/develop/LICENSE)
+[![Documentation](https://img.shields.io/badge/Documentation-blue)](https://cakeissues.net)
+[![Join in the discussion on the Cake repository](https://img.shields.io/badge/GitHub-Discussions-green?logo=github)](https://github.com/orgs/cake-build/discussions/categories/extension-q-a)
+![Stable Release](https://img.shields.io/nuget/v/Cake.Issues?label=Stable)
+![Pre-Release)](https://img.shields.io/nuget/vpre/Cake.Issues?label=Pre-Release)
 
-For more information about this addin see the [Cake.Issues website](https://cakeissues.net)
-and for general information about the Cake build automation system see the [Cake website](http://cakebuild.net).
+The Cake.Issues addins for the [Cake build automation system](https://cakebuild.net) offer an extensive and flexible solution for reading linting issues.
 
-[![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/cake-contrib/Cake.Issues/blob/develop/LICENSE)
+Cake.Issues redefines issue management within the Cake build system by offering a comprehensive, universal, and extensible solution.
+The unique capabilities of the addins empower development teams to enforce coding standards, generate insightful reports,
+seamlessly incorporate various linting tools, and streamlining the integration with pull requests.
+With its [modular architecture] and extensive [set of aliases], Cake.Issues provides a future-proof infrastructure for issue management
+in Cake builds, fostering a more efficient and adaptable development process.
 
-## Information
+For more information about the addins see the [Cake.Issues website](https://cakeissues.net).
+For general information about the Cake build automation system see the [Cake website](http://cakebuild.net).
 
-| | Stable | Pre-release |
-|:--:|:--:|:--:|
-|GitHub Release|-|[![GitHub release](https://img.shields.io/github/release/cake-contrib/Cake.Issues.svg)](https://github.com/cake-contrib/Cake.Issues/releases/latest)|
-|NuGet|[![NuGet](https://img.shields.io/nuget/v/Cake.Issues.svg)](https://www.nuget.org/packages/Cake.Issues)|[![NuGet](https://img.shields.io/nuget/vpre/Cake.Issues.svg)](https://www.nuget.org/packages/Cake.Issues)|
+## Table of Contents
 
-## Build Status
+- [Background](#background)
+- [Install](#install)
+- [Usage](#usage)
+- [Support & Discussion](#support--discussion)
+- [Addins](#addins)
+- [API](#api)
+- [Contributing](#contributing)
+- [License](#license)
 
-| | Develop | Master |
-|:--:|:--:|:--:|
-|AppVeyor Windows|[![Build status](https://ci.appveyor.com/api/projects/status/sde2oe3lu4kpmw0r/branch/develop?svg=true)](https://ci.appveyor.com/project/cakecontrib/cake-issues/branch/develop)|[![Build status](https://ci.appveyor.com/api/projects/status/sde2oe3lu4kpmw0r/branch/master?svg=true)](https://ci.appveyor.com/project/cakecontrib/cake-issues/branch/master)|
-|Azure DevOps Windows|[![Build Status](https://dev.azure.com/cake-contrib/Cake.Issues/_apis/build/status/cake-contrib.Cake.Issues?branchName=develop&jobName=Windows)](https://dev.azure.com/cake-contrib/Cake.Issues/_build/latest?definitionId=2&branchName=develop)|[![Build Status](https://dev.azure.com/cake-contrib/Cake.Issues/_apis/build/status/cake-contrib.Cake.Issues?branchName=master&jobName=Windows)](https://dev.azure.com/cake-contrib/Cake.Issues/_build/latest?definitionId=2&branchName=master)|
+## Background
 
-## Code Coverage
+### Unique Problem Solving
 
-[![Coverage Status](https://coveralls.io/repos/github/cake-contrib/Cake.Issues/badge.svg?branch=develop)](https://coveralls.io/github/cake-contrib/Cake.Issues?branch=develop)
+Some examples how Cake.Issues can help development teams to improve code quality.
 
-## Quick Links
+**Break build on linting issues:**
 
-- [Documentation](https://cakeissues.net)
+Cake.Issues provides a seamless integration, allowing you to enforce coding standards by breaking builds when linting issues are detected.
 
-## Discussion
+**Reports:**
 
-For questions and to discuss ideas & feature requests, use the [GitHub discussions on the Cake GitHub repository](https://github.com/cake-build/cake/discussions), under the [Extension Q&A](https://github.com/cake-build/cake/discussions/categories/extension-q-a) category.
+Craft detailed and visually appealing reports for linting issues directly within your Cake build.
+The addins facilitates easy identification and resolution of linting concerns, enhancing the overall code quality.
 
-[![Join in the discussion on the Cake repository](https://img.shields.io/badge/GitHub-Discussions-green?logo=github)](https://github.com/cake-build/cake/discussions)
+**Pull Requests integration:**
+
+Ensure linting issues are promptly addressed by having them reported as comments on pull requests.
+Cake.Issues bridges the gap between linting tools and version control systems, fostering efficient collaboration during code reviews.
+
+### Universal Compatibility
+
+**Build System Agnosticism:**
+
+Embrace the freedom to choose the build system that best suit your needs.
+If your current build system lacks tasks for reporting issues in pull requests, Cake.Issues steps in to fill that void seamlessly.
+In the case of using multiple CI services, Cake.Issues guarantees a consistent feature set across all of them.
+
+**Diverse Linting Tool Support:**
+
+Regardless of the linting tools you use, Cake.Issues ensures that you're not left out.
+Cake.Issues supports a [variety of analyzers and linters], allowing you to incorporate new tools effortlessly
+while maintaining integration with existing ones.
+
+### Unprecedented Extensibility
+
+**Modular Architecture:**
+
+The Cake.Issues addin breaks away from the norm by offering a [modular architecture].
+Comprising [over 15 distinct addins], it presents a cohesive solution through more than [75 aliases] for Cake builds,
+providing unparalleled flexibility.
+
+**Extensible Infrastructure:**
+
+Designed with extensibility in mind, Cake.Issues provides [extension points] for supporting additional analyzers, linters,
+report formats, and code review systems.
+This adaptability ensures that your build scripts can evolve with the ever-changing landscape of development tools.
+
+## Install
+
+Integrating Cake.Issues into your Cake build is straightforward.
+Developers can quickly configure the addins to work with their preferred linting tools and version control system.
+With minimal setup, teams can enjoy the benefits of enhanced code quality management seamlessly integrated into their existing build pipeline.
+
+The Cake Issues addins are deployed as NuGet packages.
+
+In Cake Scripting running they can be added using the [addin preprocessor directive](https://cakebuild.net/docs/writing-builds/preprocessor-directives/addin):
+
+```csharp
+#addin nuget:?package=Cake.Issues&version=x.x.x
+```
+
+In Cake Frosting they can be added using package references:
+
+```csharp
+<PackageReference Include="Cake.Issues" Version="x.x.x" />
+```
+
+See [list of available addins](https://cakeissues.net/addins/).
+
+### Compatibility
+
+See [Release Notes](https://cakeissues.net/docs/overview/release-notes/Cake.Issues) for requirements for each specific version.
+
+## Usage
+
+See [Website](https://cakeissues.net/docs/usage/) for detailed usage instructions.
+
+## Support & Discussion
+
+For questions and to discuss ideas & feature requests, use the [GitHub discussions on the Cake GitHub repository](https://github.com/cake-build/cake/discussions), under the [Extension Q&A](https://github.com/orgs/cake-build/discussions/categories/extension-q-a) category.
+
+## Addins
+
+| Addin | Description |
+|:--:|-|
+| [Cake.Issues](https://www.nuget.org/packages/Cake.Issues) | Addin providing the aliases for creating and reading of issues. |
+| [Cake.Issues.PullRequests](https://www.nuget.org/packages/Cake.Issues.PullRequests) | Addin providing the aliases for writing issues to pull requests and build servers. |
+| [Cake.Issues.Reporting](https://www.nuget.org/packages/Cake.Issues.Reporting) | Addin providing the aliases for creating reports. |
+
+## API
+
+The Cake Issues addins provide a wide range of additional aliases which can be used in Cake builds.
+See [API reference](https://cakeissues.net/dsl/) for an overview.
 
 ## Contributing
 
 Contributions are welcome. See [Contribution Guidelines](CONTRIBUTING.md).
+
+## License
+
+[MIT License - Copyright © BBT Software AG and contributors](LICENSE)
+
+Binary distributions for some addins contain third-party code which is licensed under its own respective license.
+See [LICENSE](LICENSE) for details.
+
+[modular architecture]: https://cakeissues.net/docs/fundamentals/architecture
+[extension points]: https://cakeissues.net/docs/extending/
+[set of aliases]: https://cakeissues.net/dsl/
+[variety of analyzers and linters]: https://cakeissues.net/addins/issue-provider/
+[over 15 distinct addins]: https://cakeissues.net/addins/
+[75 aliases]: https://cakeissues.net/dsl/


### PR DESCRIPTION
Updates README to match the content better, since multiple NuGet packages are published from this repository and more are planned to be merged.

Also changes format to follow https://github.com/RichardLitt/standard-readme.

README can in the future also be used inside the NuGet packages.