### PR TITLE
Unify author across NuGet package and assembly metadata

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.MsBuild.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Frosting.Issues.MsBuild</id>
     <title>Cake.Frosting.Issues.MsBuild</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>MsBuild support for the Cake.Issues addin for Cake Frosting</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.DocFx.nuspec
+++ b/nuspec/nuget/Cake.Issues.DocFx.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.DocFx</id>
     <title>Cake.Issues.DocFx</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>DocFx support for the Cake.Issues addin for Cake Build Automation System</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.EsLint.nuspec
+++ b/nuspec/nuget/Cake.Issues.EsLint.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.EsLint</id>
     <title>Cake.Issues.EsLint</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>ESLint support for the Cake.Issues addin for Cake Build Automation System</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.InspectCode.nuspec
+++ b/nuspec/nuget/Cake.Issues.InspectCode.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.InspectCode</id>
     <title>Cake.Issues.InspectCode</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>JetBrains Inspect Code support for the Cake.Issues addin for Cake Build Automation System</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.Markdownlint.nuspec
+++ b/nuspec/nuget/Cake.Issues.Markdownlint.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.Markdownlint</id>
     <title>Cake.Issues.Markdownlint</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>Markdownlint support for the Cake.Issues addin for Cake Build Automation System</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.MsBuild</id>
     <title>Cake.Issues.MsBuild</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>MsBuild support for the Cake.Issues addin for Cake Build Automation System</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.PullRequests</id>
     <title>Cake.Issues.PullRequests</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>Addin for the Cake build automation system for writing code analyzer or linter issues as comments to pull requests</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.Reporting</id>
     <title>Cake.Issues.Reporting</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>Addin for the Cake build automation system for creating reports for issues from any code analyzer or linter</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.Testing.nuspec
+++ b/nuspec/nuget/Cake.Issues.Testing.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues.Testing</id>
     <title>Cake.Issues.Testing</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>Common helpers for testing add-ins based on Cake.Issues</summary>
     <description>

--- a/nuspec/nuget/Cake.Issues.nuspec
+++ b/nuspec/nuget/Cake.Issues.nuspec
@@ -4,7 +4,7 @@
     <id>Cake.Issues</id>
     <title>Cake.Issues</title>
     <version>0.0.0</version>
-    <authors>BBT Software AG and contributors</authors>
+    <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>
     <summary>Addin for reading code analyzer or linter issues for the Cake build automation system</summary>
     <description>

--- a/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
+++ b/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
@@ -5,8 +5,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.DocFx addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>

--- a/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
+++ b/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
@@ -4,8 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>DocFx support for the Cake.Issues Addin for Cake Build Automation System</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>

--- a/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
+++ b/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
@@ -6,8 +6,7 @@
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Description>Tests for the Cake.Issues.EsLint addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
+++ b/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>EsLint support for the Cake.Issues Addin for Cake Build Automation System</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Product>Cake.Issues</Product>
   </PropertyGroup>

--- a/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
+++ b/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
@@ -5,8 +5,7 @@
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Description>Tests for the Cake.Issues.InspectCode addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>
 

--- a/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
+++ b/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
@@ -4,8 +4,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Product>Cake.Issues</Product>
     <Description>JetBrains Inspect Code support for the Cake.Issues Addin for Cake Build Automation System</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>
   

--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -5,8 +5,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.Issues.Markdownlint addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>

--- a/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
+++ b/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
@@ -4,8 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Markdownlint support for the Cake.Issues Addin for Cake Build Automation System</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>

--- a/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
@@ -6,8 +6,7 @@
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Description>Tests for the Cake.Issues.MsBuild addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues and contributors</Authors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>MsBuild support for the Cake.Issues Addin for Cake Build Automation System</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Product>Cake.Issues</Product>
   </PropertyGroup>

--- a/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
@@ -5,8 +5,7 @@
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Description>Tests for the Cake.Issues.PullRequests addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <CodeAnalysisRuleSet>..\Cake.Issues.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -5,8 +5,7 @@
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Description>Addin for the Cake build automation system for writing code analyzer or linter issues as comments to pull requests</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
@@ -5,8 +5,7 @@
     <IsPackable>false</IsPackable>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Description>Tests for the Cake.Issues.Reporting addin</Description>
-    <Authors>BBT Software AG and contributors</Authors>
-    <Company>BBT Software AG and contributors</Company>
+    <Authors>Cake Issues contributors</Authors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for the Cake build automation system for creating reports for issues from any code analyzer or linter</Description>
-    <Authors>BBT Software AG and contributors</Authors>
-    <Company>BBT Software AG and contributors</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Product>Cake.Issues</Product>
   </PropertyGroup>

--- a/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
+++ b/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Common helpers for testing addins based on Cake.Issues</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Product>Cake.Issues</Product>
   </PropertyGroup>

--- a/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
+++ b/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
@@ -6,8 +6,7 @@
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Description>Tests for the Cake.Issues addin</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for reading code analyzer or linter issues for the Cake build automation system</Description>
-    <Authors>BBT Software AG</Authors>
-    <Company>BBT Software AG</Company>
+    <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
   </PropertyGroup>
 


### PR DESCRIPTION
Uses same author in assembly metadata as in NuGet package and changes it to "Cake Issues Contributors" to be aligned with copyright changes done in #430