### PR TITLE
(GH-397) Provide Cake Frosting specific version of Cake.Issues.PullRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For questions and to discuss ideas & feature requests, use the [GitHub discussio
 | Cake Scripting Addin | Cake Frosting Addin | Description |
 |:--:|-|-|
 | [Cake.Issues](https://www.nuget.org/packages/Cake.Issues) | [Cake.Issues](https://www.nuget.org/packages/Cake.Issues) | Addin providing the aliases for creating and reading of issues. |
-| [Cake.Issues.PullRequests](https://www.nuget.org/packages/Cake.Issues.PullRequests) | [Cake.Issues.PullRequests](https://www.nuget.org/packages/Cake.Issues.PullRequests) | Addin providing the aliases for writing issues to pull requests and build servers. |
+| [Cake.Issues.PullRequests](https://www.nuget.org/packages/Cake.Issues.PullRequests) | [Cake.Frosting.Issues.PullRequests](https://www.nuget.org/packages/Cake.Frosting.Issues.PullRequests) | Addin providing the aliases for writing issues to pull requests and build servers. |
 | [Cake.Issues.Reporting](https://www.nuget.org/packages/Cake.Issues.Reporting) | [Cake.Frosting.Issues.Reporting](https://www.nuget.org/packages/Cake.Frosting.Issues.Reporting) | Addin providing the aliases for creating reports. |
 | [Cake.Issues.MsBuild](https://www.nuget.org/packages/Cake.Issues.MsBuild) | [Cake.FrostingIssues.MsBuild](https://www.nuget.org/packages/Cake.Frosting.Issues.MsBuild) | Issue provider for reading MsBuild errors and warnings. |
 | [Cake.Issues.DocFx](https://www.nuget.org/packages/Cake.Issues.DocFx) | [Cake.Issues.DocFx](https://www.nuget.org/packages/Cake.Issues.DocFx) | Issue provider for reading DocFx warnings. |

--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.nuspec
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Cake.Frosting.Issues.PullRequests</id>
+    <title>Cake.Frosting.Issues.PullRequests</title>
+    <version>0.0.0</version>
+    <authors>Cake Issues contributors</authors>
+    <owners>pascalberger, cake-contrib</owners>
+    <summary>Addin for the Cake build automation system for writing code analyzer or linter issues as comments to pull requests</summary>
+    <description>
+The pull requests issues addin for Cake allows you to write issue from any code analyzer or linter as comments to pull requests.
+
+This addin provides the aliases for writing issues to pull requests.
+It requires the core Cake.Issues addin, addins for reading issues and an addin for the specific pull request system.
+
+See the Project Site for an overview of the whole ecosystem of addins for working with issues in Cake scripts.
+
+NOTE:
+This is the version of the addin compatible with Cake Frosting.
+For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.
+    </description>
+    <license type="expression">MIT</license>
+    <projectUrl>https://cakeissues.net</projectUrl>
+    <icon>icon.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <repository type="git" url="https://github.com/cake-contrib/Cake.Issues.git"/>
+    <copyright>Copyright © Cake Issues contributors</copyright>
+    <tags>Cake Script Cake-Issues CodeAnalysis Linting Issues Pull-Requests</tags>
+    <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/4.0.0</releaseNotes>
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="icon.png" target="" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net6.0\Cake.Issues.PullRequests.dll" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net6.0\Cake.Issues.PullRequests.pdb" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net6.0\Cake.Issues.PullRequests.xml" target="lib\net6.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net7.0\Cake.Issues.PullRequests.dll" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net7.0\Cake.Issues.PullRequests.pdb" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net7.0\Cake.Issues.PullRequests.xml" target="lib\net7.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net8.0\Cake.Issues.PullRequests.dll" target="lib\net8.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net8.0\Cake.Issues.PullRequests.pdb" target="lib\net8.0" />
+    <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net8.0\Cake.Issues.PullRequests.xml" target="lib\net8.0" />
+  </files>
+</package>

--- a/nuspec/nuget/Cake.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.nuspec
@@ -14,6 +14,10 @@ This addin provides the aliases for writing issues to pull requests.
 It requires the core Cake.Issues addin, addins for reading issues and an addin for the specific pull request system.
 
 See the Project Site for an overview of the whole ecosystem of addins for working with issues in Cake scripts.
+
+NOTE:
+This is the version of the addin compatible with Cake Script Runners.
+For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.
     </description>
     <license type="expression">MIT</license>
     <projectUrl>https://cakeissues.net</projectUrl>


### PR DESCRIPTION
Introduces Cake.Frosting.Issues.PullRequests addin with dependencies on supported Cake.Issues versions

Fixes #397 