### PR TITLE
Fix publishing of Cake.Frosting.Issues.Reporting

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <id>Cake.Issues.Reporting</id>
-    <title>Cake.Issues.Reporting</title>
+    <id>Cake.Frosting.Issues.Reporting</id>
+    <title>Cake.Frosting.Issues.Reporting</title>
     <version>0.0.0</version>
     <authors>Cake Issues contributors</authors>
     <owners>bbtsoftware, pascalberger, cake-contrib</owners>


### PR DESCRIPTION
Uses correct ID for Cake.Frosting.Issues.Reporting package so that the package will be published on release