### PR TITLE
Disable update for Microsoft.Build.* packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>cake-contrib/renovate-presets:cake-issues"
+  ],
+  "packageRules": [
+    {
+      "description": "Do not update Microsoft.Build.* packages in Cake.Issues.MsBuild since required version depends on the version used in MSBuild.StructuredLogger",
+      "matchFileNames": ["src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj"],
+      "matchDepNames": ["Microsoft.Build.Framework", "Microsoft.Build.Utilities.Core"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Disable updates for Microsoft.Build.* packages in Cake.Issues.MsBuild since required version depends on the version used in MSBuild.StructuredLogger