### PR TITLE
Replace DocumentationFile with GenerateDocumentationFile

### DIFF
--- a/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
+++ b/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
@@ -8,7 +8,6 @@
     <DebugType>full</DebugType>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.DocFx.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
+++ b/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.EsLint.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
+++ b/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.GitRepository.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
+++ b/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
@@ -9,7 +9,6 @@
     <DebugType>full</DebugType>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.InspectCode.xml</DocumentationFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
+++ b/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
@@ -8,7 +8,6 @@
     <DebugType>full</DebugType>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Markdownlint.xml</DocumentationFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.MsBuild.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.AppVeyor.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.PullRequests.AzureDevOps/Cake.Issues.PullRequests.AzureDevOps.csproj
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/Cake.Issues.PullRequests.AzureDevOps.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.AzureDevOps.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.PullRequests.GitHubActions/Cake.Issues.PullRequests.GitHubActions.csproj
+++ b/src/Cake.Issues.PullRequests.GitHubActions/Cake.Issues.PullRequests.GitHubActions.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.GitHubActions.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -10,7 +10,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
+++ b/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.Console.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.Generic.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.Sarif.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Reporting.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Sarif/Cake.Issues.Sarif.csproj
+++ b/src/Cake.Issues.Sarif/Cake.Issues.Sarif.csproj
@@ -8,7 +8,6 @@
     <DebugType>full</DebugType>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Sarif.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Terraform/Cake.Issues.Terraform.csproj
+++ b/src/Cake.Issues.Terraform/Cake.Issues.Terraform.csproj
@@ -8,7 +8,6 @@
     <DebugType>full</DebugType>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Terraform.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
+++ b/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.Testing.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -9,7 +9,6 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.ruleset</CodeAnalysisRuleSet>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>
     <Product>Cake.Issues</Product>
-   </PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
@@ -15,6 +15,9 @@
   </ItemGroup>
 
   <!-- Properties for addin projects -->
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">


### PR DESCRIPTION
Replace `DocumentationFile` property in project files with "GenerateDocumentationFile` property for all addin projects