### PR TITLE
Ignore LitJson in test coverage

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -27,7 +27,7 @@ ToolSettings.SetToolPreprocessorDirectives(
 
 ToolSettings.SetToolSettings(
     context: Context,
-    testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Cake.Issues]LitJson.* -[Shouldly]* -[DiffEngine]* -[EmptyFiles]*",
+    testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[Cake.Issues.Reporting.Generic]LitJson.* -[Shouldly]* -[DiffEngine]* -[EmptyFiles]*",
     testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
     testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs");
 


### PR DESCRIPTION
LitJson is no longer included in Cake.Issues, but there is still LitJson used in Cake.Issues.Reporting.Generic which should be excluded from code coverage reports.