### PR TITLE
Introduce constructor accepting ICakeLog

### DIFF
--- a/src/Cake.Issues.PullRequests.GitHubActions.Tests/GitHubActionsPullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.GitHubActions.Tests/GitHubActionsPullRequestSystemTests.cs
@@ -1,0 +1,42 @@
+﻿namespace Cake.Issues.PullRequests.GitHubActions.Tests
+{
+    using Cake.Core.Diagnostics;
+    using Cake.Issues.Testing;
+    using Cake.Testing;
+    using Xunit;
+
+    public sealed class GitHubActionsPullRequestSystemTests
+    {
+        public sealed class TheCtor
+        {
+            [Fact]
+            public void Should_Throw_If_Log_Is_Null()
+            {
+                // Given
+                const ICakeLog log = null;
+                var settings =
+                    new GitHubActionsBuildSettings();
+
+                // When
+                var result = Record.Exception(() => new GitHubActionsPullRequestSystem(log, settings));
+
+                // Then
+                result.IsArgumentNullException("log");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                var log = new FakeLog();
+                const GitHubActionsBuildSettings settings = null;
+
+                // When
+                var result = Record.Exception(() => new GitHubActionsPullRequestSystem(log, settings));
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+        }
+    }
+}

--- a/src/Cake.Issues.PullRequests.GitHubActions/GitHubActionsBuildsAliases.cs
+++ b/src/Cake.Issues.PullRequests.GitHubActions/GitHubActionsBuildsAliases.cs
@@ -34,7 +34,7 @@
         {
             context.NotNull(nameof(context));
 
-            return new GitHubActionsPullRequestSystem(context, new GitHubActionsBuildSettings());
+            return new GitHubActionsPullRequestSystem(context.Log, new GitHubActionsBuildSettings());
         }
 
         /// <summary>
@@ -70,7 +70,7 @@
             context.NotNull(nameof(context));
             settings.NotNull(nameof(settings));
 
-            return new GitHubActionsPullRequestSystem(context, settings);
+            return new GitHubActionsPullRequestSystem(context.Log, settings);
         }
     }
 }

--- a/src/Cake.Issues.PullRequests.GitHubActions/GitHubActionsPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.GitHubActions/GitHubActionsPullRequestSystem.cs
@@ -18,14 +18,25 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="GitHubActionsPullRequestSystem"/> class.
         /// </summary>
-        /// <param name="context">The Cake context.</param>
+        /// <param name="log">The Cake log.</param>
         /// <param name="settings">Settings for writing the issues to GitHub Actions.</param>
-        public GitHubActionsPullRequestSystem(ICakeContext context, GitHubActionsBuildSettings settings)
-            : base(context?.Log)
+        public GitHubActionsPullRequestSystem(ICakeLog log, GitHubActionsBuildSettings settings)
+            : base(log)
         {
             settings.NotNull(nameof(settings));
 
             this.settings = settings;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitHubActionsPullRequestSystem"/> class.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="settings">Settings for writing the issues to GitHub Actions.</param>
+        [Obsolete("Please use the constructor which takes an ICakeLog instead.")]
+        public GitHubActionsPullRequestSystem(ICakeContext context, GitHubActionsBuildSettings settings)
+            : this(context?.Log, settings)
+        {
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Introduce constructor for `GitHubActionsPullRequestSystem` which excpects a `ICakeLog` instead of a `ICakeContext`. The old constructor expecting an `ICakeContext` has been marked as obsolete and will be removed with 5.0