### PR TITLE
Use global usings and project reference for test projects

### DIFF
--- a/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
+++ b/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.DocFx\Cake.Issues.DocFx.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.DocFx.Tests/DocFxProviderFixture.cs
+++ b/src/Cake.Issues.DocFx.Tests/DocFxProviderFixture.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.DocFx.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
 
     internal class DocFxProviderFixture : BaseConfigurableIssueProviderFixture<DocFxIssuesProvider, DocFxIssuesSettings>
     {

--- a/src/Cake.Issues.DocFx.Tests/DocFxProviderTests.cs
+++ b/src/Cake.Issues.DocFx.Tests/DocFxProviderTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.DocFx.Tests
 {
-    using System.Linq;
     using System.Runtime.InteropServices;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class DocFxProviderTests
     {

--- a/src/Cake.Issues.DocFx.Tests/DocFxSettingsTests.cs
+++ b/src/Cake.Issues.DocFx.Tests/DocFxSettingsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.DocFx.Tests
 {
-    using System;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class DocFxSettingsTests
     {

--- a/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
+++ b/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.EsLint\Cake.Issues.EsLint.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.EsLint.Tests/EsLintIssuesProviderFixture.cs
+++ b/src/Cake.Issues.EsLint.Tests/EsLintIssuesProviderFixture.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.EsLint.Tests
 {
-    using Cake.Issues.Testing;
-
     public class EsLintIssuesProviderFixture<T>
         : BaseMultiFormatIssueProviderFixture<EsLintIssuesProvider, EsLintIssuesSettings, T>
         where T : BaseEsLintLogFileFormat

--- a/src/Cake.Issues.EsLint.Tests/EsLintIssuesProviderTests.cs
+++ b/src/Cake.Issues.EsLint.Tests/EsLintIssuesProviderTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace Cake.Issues.EsLint.Tests
 {
-    using System.Text;
     using Cake.Core.Diagnostics;
     using Cake.Issues.EsLint.LogFileFormat;
-    using Cake.Testing;
-    using Xunit;
 
     public sealed class EsLintIssuesProviderTests
     {

--- a/src/Cake.Issues.EsLint.Tests/EsLintIssuesSettingsTests.cs
+++ b/src/Cake.Issues.EsLint.Tests/EsLintIssuesSettingsTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.EsLint.Tests
 {
-    using System;
     using Cake.Core.IO;
     using Cake.Issues.EsLint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class EsLintIssuesSettingsTests
     {

--- a/src/Cake.Issues.EsLint.Tests/EsLintRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.EsLint.Tests/EsLintRuleUrlResolverTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.EsLint.Tests
 {
-    using System;
-    using Shouldly;
-    using Xunit;
-
     public sealed class EsLintRuleUrlResolverTests
     {
         public sealed class TheResolveRuleUrlMethod

--- a/src/Cake.Issues.EsLint.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Issues.EsLint.Tests/ExceptionAssertExtensions.cs
@@ -1,8 +1,5 @@
 ﻿namespace Cake.Issues.EsLint.Tests
 {
-    using System;
-    using Xunit;
-
     public static class ExceptionAssertExtensions
     {
         public static void IsArgumentNullException(this Exception exception, string parameterName)

--- a/src/Cake.Issues.EsLint.Tests/LogFileFormat/JsonLogFileFormatTests.cs
+++ b/src/Cake.Issues.EsLint.Tests/LogFileFormat/JsonLogFileFormatTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.EsLint.Tests.LogFileFormat
 {
-    using System;
-    using System.Linq;
     using Cake.Issues.EsLint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class JsonLogFileFormatTests
     {

--- a/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
+++ b/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.GitRepository\Cake.Issues.GitRepository.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.GitRepository.Tests/GitRunnerFixture.cs
+++ b/src/Cake.Issues.GitRepository.Tests/GitRunnerFixture.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.GitRepository.Tests
 {
-    using System.Collections.Generic;
     using Cake.Testing.Fixtures;
 
     internal class GitRunnerFixture : ToolFixture<GitRunnerSettings>

--- a/src/Cake.Issues.GitRepository.Tests/GitRunnerTests.cs
+++ b/src/Cake.Issues.GitRepository.Tests/GitRunnerTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.GitRepository.Tests
 {
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class GitRunnerTests
     {
         public sealed class TheRunCommandMethod

--- a/src/Cake.Issues.GitRepository.Tests/IssueBuilderExtensionsTests.cs
+++ b/src/Cake.Issues.GitRepository.Tests/IssueBuilderExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.GitRepository.Tests
 {
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueBuilderExtensionsTests
     {
         public sealed class TheOfRuleMethod

--- a/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
+++ b/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
@@ -22,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.InspectCode\Cake.Issues.InspectCode.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.InspectCode.Tests/ExtensionsTests.cs
+++ b/src/Cake.Issues.InspectCode.Tests/ExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.InspectCode.Tests
 {
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class ExtensionsTests
     {

--- a/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesProviderFixture.cs
+++ b/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesProviderFixture.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.InspectCode.Tests
 {
-    using Cake.Issues.Testing;
-
     internal class InspectCodeIssuesProviderFixture(string fileResourceName)
         : BaseConfigurableIssueProviderFixture<InspectCodeIssuesProvider, InspectCodeIssuesSettings>(fileResourceName)
     {

--- a/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesProviderTests.cs
+++ b/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesProviderTests.cs
@@ -1,12 +1,6 @@
 ﻿namespace Cake.Issues.InspectCode.Tests
 {
-    using System;
-    using System.Linq;
     using System.Runtime.InteropServices;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class InspectCodeIssuesProviderTests

--- a/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesSettingsTests.cs
+++ b/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesSettingsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.InspectCode.Tests
 {
-    using System;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class InspectCodeIssuesSettingsTests

--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Markdownlint\Cake.Issues.Markdownlint.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliJsonLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliJsonLogFileFormatTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Markdownlint.Tests.LogFileFormat
 {
-    using System;
-    using System.Linq;
     using Cake.Issues.Markdownlint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class MarkdownlintCliJsonLogFileFormatTests
     {

--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Markdownlint.Tests.LogFileFormat
 {
-    using System;
-    using System.Linq;
     using Cake.Issues.Markdownlint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class MarkdownlintCliLogFileFormatTests
     {

--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintV1LogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintV1LogFileFormatTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Markdownlint.Tests.LogFileFormat
 {
-    using System;
-    using System.Linq;
     using Cake.Issues.Markdownlint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class MarkdownlintV1LogFileFormatTests
     {

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintIssuesProviderFixture.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintIssuesProviderFixture.cs
@@ -1,7 +1,6 @@
 ﻿namespace Cake.Issues.Markdownlint.Tests
 {
     using Cake.Issues.Markdownlint;
-    using Cake.Issues.Testing;
 
     internal class MarkdownlintIssuesProviderFixture<T>
         : BaseMultiFormatIssueProviderFixture<MarkdownlintIssuesProvider, MarkdownlintIssuesSettings, T>

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintIssuesProviderTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintIssuesProviderTests.cs
@@ -3,9 +3,6 @@
     using Cake.Core.Diagnostics;
     using Cake.Issues.Markdownlint;
     using Cake.Issues.Markdownlint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Xunit;
 
     public sealed class MarkdownlintIssuesProviderTests
     {

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintIssuesSettingsTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintIssuesSettingsTests.cs
@@ -1,13 +1,8 @@
 ﻿namespace Cake.Issues.Markdownlint.Tests
 {
-    using System;
     using Cake.Core.IO;
     using Cake.Issues.Markdownlint;
     using Cake.Issues.Markdownlint.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class MarkdownlintIssuesSettingsTests
     {

--- a/src/Cake.Issues.Markdownlint.Tests/MarkdownlintRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/MarkdownlintRuleUrlResolverTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Markdownlint.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class MarkdownlintRuleUrlResolverTests
     {
         public sealed class TheResolveRuleUrlMethod

--- a/src/Cake.Issues.MsBuild.Tests/BaseMsBuildLogFileFormatTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/BaseMsBuildLogFileFormatTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.MsBuild.Tests
 {
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class BaseMsBuildLogFileFormatTests
     {
         public sealed class TheValidateFilePathMethod

--- a/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.MsBuild\Cake.Issues.MsBuild.csproj" />
   </ItemGroup>
 

--- a/src/Cake.Issues.MsBuild.Tests/FakeMsBuildLogFileFormat.cs
+++ b/src/Cake.Issues.MsBuild.Tests/FakeMsBuildLogFileFormat.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.MsBuild.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
 
     internal class FakeMsBuildLogFileFormat(ICakeLog log) : BaseMsBuildLogFileFormat(log)

--- a/src/Cake.Issues.MsBuild.Tests/LogFileFormat/BinaryLogFileFormatTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/LogFileFormat/BinaryLogFileFormatTests.cs
@@ -1,13 +1,8 @@
 ﻿namespace Cake.Issues.MsBuild.Tests.LogFileFormat
 {
-    using System;
-    using System.Linq;
     using System.Runtime.InteropServices;
     using Cake.Core.Diagnostics;
     using Cake.Issues.MsBuild.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BinaryLogFileFormatTests
     {

--- a/src/Cake.Issues.MsBuild.Tests/LogFileFormat/XmlFileLoggerLogFileFormatTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/LogFileFormat/XmlFileLoggerLogFileFormatTests.cs
@@ -1,14 +1,8 @@
 ﻿namespace Cake.Issues.MsBuild.Tests.LogFileFormat
 {
-    using System;
-    using System.IO;
-    using System.Linq;
     using System.Runtime.InteropServices;
     using Cake.Core.Diagnostics;
     using Cake.Issues.MsBuild.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class XmlFileLoggerLogFileFormatTests
     {

--- a/src/Cake.Issues.MsBuild.Tests/MsBuildIssuesProviderFixture.cs
+++ b/src/Cake.Issues.MsBuild.Tests/MsBuildIssuesProviderFixture.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.MsBuild.Tests
 {
-    using Cake.Issues.Testing;
-
     internal class MsBuildIssuesProviderFixture<T>
         : BaseMultiFormatIssueProviderFixture<MsBuildIssuesProvider, MsBuildIssuesSettings, T>
         where T : BaseMsBuildLogFileFormat

--- a/src/Cake.Issues.MsBuild.Tests/MsBuildIssuesProviderTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/MsBuildIssuesProviderTests.cs
@@ -2,9 +2,6 @@
 {
     using Cake.Core.Diagnostics;
     using Cake.Issues.MsBuild.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Xunit;
 
     public sealed class MsBuildIssuesProviderTests
     {

--- a/src/Cake.Issues.MsBuild.Tests/MsBuildIssuesSettingsTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/MsBuildIssuesSettingsTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.MsBuild.Tests
 {
-    using System;
     using Cake.Core.IO;
     using Cake.Issues.MsBuild.LogFileFormat;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class MsBuildIssuesSettingsTests
     {

--- a/src/Cake.Issues.MsBuild.Tests/MsBuildRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.MsBuild.Tests/MsBuildRuleUrlResolverTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.MsBuild.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class MsBuildRuleUrlResolverTests
     {
         public sealed class TheResolveRuleUrlMethod

--- a/src/Cake.Issues.PullRequests.AppVeyor.Tests/AppVeyorBuildSettingsTests.cs
+++ b/src/Cake.Issues.PullRequests.AppVeyor.Tests/AppVeyorBuildSettingsTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.AppVeyor.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class AppVeyorBuildSettingsTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.AppVeyor.Tests/AppVeyorPullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.AppVeyor.Tests/AppVeyorPullRequestSystemTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.AppVeyor.Tests
 {
     using Cake.Core;
-    using Cake.Issues.Testing;
-    using Xunit;
 
     public sealed class AppVeyorPullRequestSystemTests
     {

--- a/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.PullRequests.AppVeyor\Cake.Issues.PullRequests.AppVeyor.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemSettingsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemSettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.AzureDevOps.Tests
 {
-    using System;
     using Cake.AzureDevOps.Authentication;
-    using Cake.Issues.Testing;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsPullRequestSystemSettingsTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemTests.cs
@@ -1,11 +1,7 @@
 ﻿namespace Cake.Issues.PullRequests.AzureDevOps.Tests
 {
-    using System;
     using Cake.AzureDevOps.Authentication;
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsPullRequestSystemTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Cake.Issues.PullRequests.AzureDevOps.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Cake.Issues.PullRequests.AzureDevOps.Tests.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.PullRequests.AzureDevOps\Cake.Issues.PullRequests.AzureDevOps.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsCheckingCommitIdCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsCheckingCommitIdCapabilityTests.cs
@@ -2,10 +2,7 @@
 {
     using Cake.Core.Diagnostics;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
     using NSubstitute;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsCheckingCommitIdCapabilityTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsDiscussionThreadsCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsDiscussionThreadsCapabilityTests.cs
@@ -2,10 +2,7 @@
 {
     using Cake.Core.Diagnostics;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
     using NSubstitute;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsDiscussionThreadsCapabilityTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsFilteringByModifiedFilesCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsFilteringByModifiedFilesCapabilityTests.cs
@@ -2,10 +2,7 @@
 {
     using Cake.Core.Diagnostics;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
     using NSubstitute;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsFilteringByModifiedFilesCapabilityTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentExtensionsTests.cs
@@ -2,9 +2,6 @@
 {
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class CommentExtensionsTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentThreadStatusExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentThreadStatusExtensionsTests.cs
@@ -2,8 +2,6 @@
 {
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
-    using Shouldly;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class CommentThreadStatusExtensionsTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/GitPullRequestCommentThreadExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/GitPullRequestCommentThreadExtensionsTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.PullRequests.AzureDevOps.Tests.Capabilities
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class GitPullRequestCommentThreadExtensionsTests

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/ContentProviderTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/ContentProviderTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.AzureDevOps.Tests
 {
-    using System;
-    using Shouldly;
-    using Xunit;
-
     // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class ContentProviderTests
     {

--- a/src/Cake.Issues.PullRequests.GitHubActions.Tests/Cake.Issues.PullRequests.GitHubActions.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.GitHubActions.Tests/Cake.Issues.PullRequests.GitHubActions.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.PullRequests.GitHubActions\Cake.Issues.PullRequests.GitHubActions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.PullRequests.GitHubActions.Tests/GitHubActionsBuildSettingsTests.cs
+++ b/src/Cake.Issues.PullRequests.GitHubActions.Tests/GitHubActionsBuildSettingsTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.GitHubActions.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class GitHubActionsBuildSettingsTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.GitHubActions.Tests/GitHubActionsPullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.GitHubActions.Tests/GitHubActionsPullRequestSystemTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.GitHubActions.Tests
 {
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Xunit;
 
     public sealed class GitHubActionsPullRequestSystemTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/BaseCheckingCommitIdCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/BaseCheckingCommitIdCapabilityTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseCheckingCommitIdCapabilityTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/BaseDiscussionThreadsCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/BaseDiscussionThreadsCapabilityTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseDiscussionThreadsCapabilityTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/BaseFilteringByModifiedFilesCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/BaseFilteringByModifiedFilesCapabilityTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseFilteringByModifiedFilesCapabilityTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/BasePullRequestSystemCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/BasePullRequestSystemCapabilityTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BasePullRequestSystemCapabilityTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/BasePullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/BasePullRequestSystemTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BasePullRequestSystemTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
    <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.PullRequests\Cake.Issues.PullRequests.csproj" />
    </ItemGroup>
 </Project>

--- a/src/Cake.Issues.PullRequests.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Issues.PullRequests.Tests/ExceptionAssertExtensions.cs
@@ -1,8 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System;
-    using Xunit;
-
     public static class ExceptionAssertExtensions
     {
         public static void IsPullRequestIssuesException(this Exception exception, string message)

--- a/src/Cake.Issues.PullRequests.Tests/FakeDiscussionThreadsCapability.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakeDiscussionThreadsCapability.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
 
     /// <summary>

--- a/src/Cake.Issues.PullRequests.Tests/FakeFilteringByModifiedFilesCapability.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakeFilteringByModifiedFilesCapability.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
 

--- a/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
 
     /// <summary>

--- a/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystemBuilder.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystemBuilder.cs
@@ -1,9 +1,7 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
-    using Cake.Testing;
 
     /// <summary>
     /// Class to create instances of <see cref="FakePullRequestSystem"/> with a fluent API.

--- a/src/Cake.Issues.PullRequests.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IIssueExtensionsTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IIssueExtensionsTests
     {
         public sealed class TheSortWithDefaultPriorizationMethod

--- a/src/Cake.Issues.PullRequests.Tests/ISupportCheckingCommitIdExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/ISupportCheckingCommitIdExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class ISupportCheckingCommitIdExtensionsTests
     {
         public sealed class TheIsCurrentCommitIdExtension

--- a/src/Cake.Issues.PullRequests.Tests/IssueCommentInfoTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IssueCommentInfoTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueCommentInfoTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.Tests/IssueFiltererFixture.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IssueFiltererFixture.cs
@@ -1,9 +1,6 @@
 namespace Cake.Issues.PullRequests.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
-    using Cake.Testing;
 
     internal class IssueFiltererFixture
     {

--- a/src/Cake.Issues.PullRequests.Tests/IssueFiltererTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IssueFiltererTests.cs
@@ -1,13 +1,7 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.InteropServices;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class IssueFiltererTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorForIssueProvidersFixture.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorForIssueProvidersFixture.cs
@@ -1,10 +1,6 @@
 namespace Cake.Issues.PullRequests.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
 
     internal class OrchestratorForIssueProvidersFixture
     {

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorForIssuesFixture.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorForIssuesFixture.cs
@@ -1,9 +1,6 @@
 namespace Cake.Issues.PullRequests.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
-    using Cake.Testing;
 
     internal class OrchestratorForIssuesFixture
     {

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -1,12 +1,7 @@
 namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Runtime.InteropServices;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class OrchestratorTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestDiscussionThreadTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestDiscussionThreadTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
     using System.Runtime.InteropServices;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class PullRequestDiscussionThreadTests
     {

--- a/src/Cake.Issues.PullRequests.Tests/PullRequestIssueResultTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/PullRequestIssueResultTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class PullRequestIssueResultTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.Tests/ReportIssuesToPullRequestSettingsTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/ReportIssuesToPullRequestSettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.PullRequests.Tests
 {
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class ReportIssuesToPullRequestSettingsTests
     {

--- a/src/Cake.Issues.Reporting.Console.Tests/Cake.Issues.Reporting.Console.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Console.Tests/Cake.Issues.Reporting.Console.Tests.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Reporting.Console\Cake.Issues.Reporting.Console.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportFixture.cs
+++ b/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportFixture.cs
@@ -1,13 +1,9 @@
 ﻿namespace Cake.Issues.Reporting.Console.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
     using Cake.Issues.Serialization;
-    using Cake.Testing;
-    using Shouldly;
 
     internal class ConsoleIssueReportFixture
     {

--- a/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportGeneratorTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Console.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Xunit;
-
     public sealed class ConsoleIssueReportGeneratorTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Reporting.Generic\Cake.Issues.Reporting.Generic.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Reporting.Generic.Tests/ColumnSortOrderExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ColumnSortOrderExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
     using System.Diagnostics.CodeAnalysis;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/DevExtremeThemeExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/DevExtremeThemeExtensionsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ExceptionAssertExtensions.cs
@@ -1,10 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using Microsoft.CSharp.RuntimeBinder;
-    using Shouldly;
-    using Xunit;
 
     /// <summary>
     /// Extensions for asserting exceptions.

--- a/src/Cake.Issues.Reporting.Generic.Tests/ExpandoObjectExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ExpandoObjectExtensionsTests.cs
@@ -1,11 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Dynamic;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFixture.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFixture.cs
@@ -1,11 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Cake.Core.Diagnostics;
-    using Cake.Testing;
-    using Shouldly;
 
     internal class GenericIssueReportFixture
     {

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsExtensionsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
     using System.Diagnostics.CodeAnalysis;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsTests.cs
@@ -1,14 +1,9 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
-    using System.Linq;
     using System.Text;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportGeneratorTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportTemplateExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportTemplateExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
     using System.Diagnostics.CodeAnalysis;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridColumnDescriptionTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridColumnDescriptionTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridTemplateTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridTemplateTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
     using HtmlAgilityPack;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/IIssueExtensionsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/IdeIntegrationSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/IdeIntegrationSettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
     using System.Diagnostics.CodeAnalysis;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/Properties/ProjectInfo.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Properties/ProjectInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.InteropServices;
-using Xunit;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Cake.Issues.Reporting.Generic.Tests/StringExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/StringExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
     using System.Diagnostics.CodeAnalysis;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/UriExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/UriExtensionsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Generic.Tests/ViewBagHelperTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ViewBagHelperTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
     using System.Diagnostics.CodeAnalysis;
-    using Shouldly;
-    using Xunit;
 
     [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]

--- a/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Reporting.Sarif\Cake.Issues.Reporting.Sarif.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportFixture.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportFixture.cs
@@ -1,11 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Sarif.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using System.IO;
     using Cake.Core.Diagnostics;
-    using Cake.Testing;
-    using Shouldly;
 
     internal class SarifIssueReportFixture
     {

--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
@@ -1,13 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Sarif.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
     using Microsoft.CodeAnalysis.Sarif;
     using Newtonsoft.Json;
-    using Shouldly;
-    using Xunit;
 
     public sealed class SarifIssueReportGeneratorTests
     {

--- a/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Reporting\Cake.Issues.Reporting.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Reporting.Tests/CreateIssueReportFromIssueProviderSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Tests/CreateIssueReportFromIssueProviderSettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Tests
 {
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class CreateIssueReportFromIssueProviderSettingsTests
     {

--- a/src/Cake.Issues.Reporting.Tests/CreateIssueReportSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Tests/CreateIssueReportSettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Reporting.Tests
 {
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class CreateIssueReportSettingsTests
     {

--- a/src/Cake.Issues.Reporting.Tests/FakeIssueReportFormat.cs
+++ b/src/Cake.Issues.Reporting.Tests/FakeIssueReportFormat.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
 

--- a/src/Cake.Issues.Reporting.Tests/IssueReportCreatorTests.cs
+++ b/src/Cake.Issues.Reporting.Tests/IssueReportCreatorTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Tests
 {
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueReportCreatorTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Reporting.Tests/IssueReportFormatFixture.cs
+++ b/src/Cake.Issues.Reporting.Tests/IssueReportFormatFixture.cs
@@ -1,9 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
     using Cake.Core.IO;
-    using Cake.Testing;
 
     internal class IssueReportFormatFixture
     {

--- a/src/Cake.Issues.Reporting.Tests/IssueReportFormatTests.cs
+++ b/src/Cake.Issues.Reporting.Tests/IssueReportFormatTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Tests
 {
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueReportFormatTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Sarif.Tests/Cake.Issues.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Sarif.Tests/Cake.Issues.Sarif.Tests.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Sarif\Cake.Issues.Sarif.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderFixture.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderFixture.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.Sarif.Tests
 {
-    using Cake.Issues.Testing;
-
     internal class SarifIssuesProviderFixture(string fileResourceName)
         : BaseConfigurableIssueProviderFixture<SarifIssuesProvider, SarifIssuesSettings>(fileResourceName)
     {

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
@@ -1,12 +1,5 @@
 ﻿namespace Cake.Issues.Sarif.Tests
 {
-    using System;
-    using System.Linq;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class SarifIssuesProviderTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesSettingsTests.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesSettingsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Sarif.Tests
 {
-    using System;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class SarifIssuesSettingsTests
     {

--- a/src/Cake.Issues.Terraform.Tests/Cake.Issues.Terraform.Tests.csproj
+++ b/src/Cake.Issues.Terraform.Tests/Cake.Issues.Terraform.Tests.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues.Terraform\Cake.Issues.Terraform.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues.Terraform.Tests/TerraformProviderFixture.cs
+++ b/src/Cake.Issues.Terraform.Tests/TerraformProviderFixture.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Terraform.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
 
     internal class TerraformProviderFixture : BaseConfigurableIssueProviderFixture<TerraformIssuesProvider, TerraformIssuesSettings>
     {

--- a/src/Cake.Issues.Terraform.Tests/TerraformProviderTests.cs
+++ b/src/Cake.Issues.Terraform.Tests/TerraformProviderTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Terraform.Tests
 {
-    using System.Linq;
     using System.Runtime.InteropServices;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class TerraformProviderTests
     {

--- a/src/Cake.Issues.Terraform.Tests/TerraformSettingsTests.cs
+++ b/src/Cake.Issues.Terraform.Tests/TerraformSettingsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Terraform.Tests
 {
-    using System;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class TerraformSettingsTests
     {

--- a/src/Cake.Issues.Tests/BaseConfigurableIssueProviderTests.cs
+++ b/src/Cake.Issues.Tests/BaseConfigurableIssueProviderTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseConfigurableIssueProviderTests
     {

--- a/src/Cake.Issues.Tests/BaseIssueComponentTests.cs
+++ b/src/Cake.Issues.Tests/BaseIssueComponentTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class BaseIssueComponentTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/BaseIssueProviderTests.cs
+++ b/src/Cake.Issues.Tests/BaseIssueProviderTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class BaseIssueProviderTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/BaseLogFileFormatTests.cs
+++ b/src/Cake.Issues.Tests/BaseLogFileFormatTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseLogFileFormatTests
     {

--- a/src/Cake.Issues.Tests/BaseMultiFormatIssueProviderSettingsTests.cs
+++ b/src/Cake.Issues.Tests/BaseMultiFormatIssueProviderSettingsTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseMultiFormatIssueProviderSettingsTests
     {

--- a/src/Cake.Issues.Tests/BaseMultiFormatIssueProviderTests.cs
+++ b/src/Cake.Issues.Tests/BaseMultiFormatIssueProviderTests.cs
@@ -1,12 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class BaseMultiFormatIssueProviderTests
     {

--- a/src/Cake.Issues.Tests/BaseRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.Tests/BaseRuleUrlResolverTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public class BaseRuleUrlResolverTests
     {
         public sealed class TheClass

--- a/src/Cake.Issues.Tests/ByteArrayExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/ByteArrayExtensionsTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using System.Linq;
     using System.Text;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class ByteArrayExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
+++ b/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
     <ProjectReference Include="..\Cake.Issues\Cake.Issues.csproj" />
   </ItemGroup>
 

--- a/src/Cake.Issues.Tests/FileLinkSettingsTests.cs
+++ b/src/Cake.Issues.Tests/FileLinkSettingsTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Xunit;
-
     public sealed class FileLinkSettingsTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/FileLinking/AzureDevOpsFileLinkSettingsBuilderTests.cs
+++ b/src/Cake.Issues.Tests/FileLinking/AzureDevOpsFileLinkSettingsBuilderTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Tests.FileLinking
 {
-    using System;
     using Cake.Issues.FileLinking;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class AzureDevOpsFileLinkSettingsBuilderTests
     {

--- a/src/Cake.Issues.Tests/FileLinking/FileLinkOptionalSettingsBuilderTests.cs
+++ b/src/Cake.Issues.Tests/FileLinking/FileLinkOptionalSettingsBuilderTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Tests.FileLinking
 {
-    using System;
-    using System.Collections.Generic;
     using Cake.Issues.FileLinking;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class FileLinkOptionalSettingsBuilderTests
     {

--- a/src/Cake.Issues.Tests/FileLinking/GitHubFileLinkSettingsBuilderTests.cs
+++ b/src/Cake.Issues.Tests/FileLinking/GitHubFileLinkSettingsBuilderTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Tests.FileLinking
 {
-    using System;
     using Cake.Issues.FileLinking;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class GitHubFileLinkSettingsBuilderTests
     {

--- a/src/Cake.Issues.Tests/FileLinking/IDictionaryExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/FileLinking/IDictionaryExtensionsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Tests.FileLinking
 {
     using Cake.Issues.FileLinking;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class IDictionaryExtensionsTests
     {

--- a/src/Cake.Issues.Tests/IIssueComparerTests.cs
+++ b/src/Cake.Issues.Tests/IIssueComparerTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IIssueComparerTests
     {
         public sealed class TheCtorWithCompareOnlyPersistentPropertiesSetToFalse

--- a/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/IIssueExtensionsTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IIssueExtensionsTests
     {
         public sealed class TheLineRangeExtension

--- a/src/Cake.Issues.Tests/IssueBuilderTests.cs
+++ b/src/Cake.Issues.Tests/IssueBuilderTests.cs
@@ -1,12 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueBuilderTests
     {
         public sealed class TheNewIssueMethodWithMessageAsIdentifier

--- a/src/Cake.Issues.Tests/IssueProviderSettingsTests.cs
+++ b/src/Cake.Issues.Tests/IssueProviderSettingsTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class IssueProviderSettingsTests
     {

--- a/src/Cake.Issues.Tests/IssueReaderTests.cs
+++ b/src/Cake.Issues.Tests/IssueReaderTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueReaderTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/IssueTests.cs
+++ b/src/Cake.Issues.Tests/IssueTests.cs
@@ -1,11 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using System.Collections.Generic;
     using System.Runtime.InteropServices;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class IssueTests
     {

--- a/src/Cake.Issues.Tests/IssuesArgumentChecksTests.cs
+++ b/src/Cake.Issues.Tests/IssuesArgumentChecksTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Xunit;
-
     public sealed class IssuesArgumentChecksTests
     {
         public sealed class TheNotNullExtension

--- a/src/Cake.Issues.Tests/IssuesFixture.cs
+++ b/src/Cake.Issues.Tests/IssuesFixture.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System.Collections.Generic;
     using Cake.Core.Diagnostics;
-    using Cake.Issues.Testing;
-    using Cake.Testing;
 
     public class IssuesFixture
     {

--- a/src/Cake.Issues.Tests/ReadIssuesSettingsTests.cs
+++ b/src/Cake.Issues.Tests/ReadIssuesSettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class ReadIssuesSettingsTests
     {

--- a/src/Cake.Issues.Tests/RepositorySettingsTests.cs
+++ b/src/Cake.Issues.Tests/RepositorySettingsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
     using Cake.Core.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class RepositorySettingsTests
     {

--- a/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueDeserializationExtensionsTests.cs
@@ -1,12 +1,7 @@
 ﻿namespace Cake.Issues.Tests.Serialization
 {
-    using System;
-    using System.Linq;
     using Cake.Core.IO;
     using Cake.Issues.Serialization;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class IssueDeserializationExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/IssueSerializationExtensionsTests.cs
@@ -1,13 +1,7 @@
 ﻿namespace Cake.Issues.Tests.Serialization
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using Cake.Core.IO;
     using Cake.Issues.Serialization;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class IssueSerializationExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Serialization/SerializableIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/SerializableIssueExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Tests.Serialization
 {
     using Cake.Issues.Serialization;
-    using Cake.Issues.Testing;
-    using Xunit;
 
     public sealed class SerializableIssueExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Serialization/SerializableIssueV2ExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/SerializableIssueV2ExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Tests.Serialization
 {
     using Cake.Issues.Serialization;
-    using Cake.Issues.Testing;
-    using Xunit;
 
     public sealed class SerializableIssueV2ExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Serialization/SerializableIssueV3ExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/SerializableIssueV3ExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Tests.Serialization
 {
     using Cake.Issues.Serialization;
-    using Cake.Issues.Testing;
-    using Xunit;
 
     public sealed class SerializableIssueV3ExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Serialization/SerializableIssueV4ExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Serialization/SerializableIssueV4ExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿namespace Cake.Issues.Tests.Serialization
 {
     using Cake.Issues.Serialization;
-    using Cake.Issues.Testing;
-    using Xunit;
 
     public sealed class SerializableIssueV4ExtensionsTests
     {

--- a/src/Cake.Issues.Tests/StringPathExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/StringPathExtensionsTests.cs
@@ -1,9 +1,6 @@
 ﻿namespace Cake.Issues.Tests
 {
     using System.Runtime.InteropServices;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
 
     public sealed class StringPathExtensionsTests
     {

--- a/src/Cake.Issues.Tests/Testing/BaseConfigurableIssueProviderFixtureTests.cs
+++ b/src/Cake.Issues.Tests/Testing/BaseConfigurableIssueProviderFixtureTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class BaseConfigurableIssueProviderFixtureTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/Testing/BaseIssueProviderFixtureTests.cs
+++ b/src/Cake.Issues.Tests/Testing/BaseIssueProviderFixtureTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class BaseIssueProviderFixtureTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/Testing/BaseMultiFormatIssueProviderFixtureTests.cs
+++ b/src/Cake.Issues.Tests/Testing/BaseMultiFormatIssueProviderFixtureTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class BaseMultiFormatIssueProviderFixtureTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/Testing/ExceptionAssertExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/Testing/ExceptionAssertExtensionsTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class ExceptionAssertExtensionsTests
     {
         public sealed class TheIsArgumentExceptionMethod

--- a/src/Cake.Issues.Tests/Testing/FakeConfigurableIssueProviderFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/FakeConfigurableIssueProviderFixture.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using Cake.Issues.Testing;
-
     internal sealed class FakeConfigurableIssueProviderFixture(string fileResourceName)
                 : BaseConfigurableIssueProviderFixture<FakeConfigurableIssueProvider, IssueProviderSettings>(fileResourceName)
     {

--- a/src/Cake.Issues.Tests/Testing/FakeIssueProviderFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/FakeIssueProviderFixture.cs
@@ -1,8 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-
     internal sealed class FakeIssueProviderFixture : BaseIssueProviderFixture<FakeIssueProvider>
     {
         private readonly List<IIssue> issues = [];

--- a/src/Cake.Issues.Tests/Testing/FakeMultiFormatIssueProviderFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/FakeMultiFormatIssueProviderFixture.cs
@@ -1,7 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using Cake.Issues.Testing;
-
     internal sealed class FakeMultiFormatIssueProviderFixture(string fileResourceName)
                 : BaseMultiFormatIssueProviderFixture<FakeMultiFormatIssueProvider, FakeMultiFormatIssueProviderSettings, FakeLogFileFormat>(fileResourceName)
     {

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerFixture.cs
@@ -1,8 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using System;
-    using System.Collections.Generic;
-
     internal class IssueCheckerFixture : IssueBuilderFixture
     {
         public IssueCheckerFixture()

--- a/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
+++ b/src/Cake.Issues.Tests/Testing/IssueCheckerTests.cs
@@ -1,11 +1,5 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
-    using System;
-    using System.Collections.Generic;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class IssueCheckerTests
     {
         public sealed class TheCheckMethodWithIssueBuilder

--- a/src/Cake.Issues.Tests/Testing/ResourceTempFileTests.cs
+++ b/src/Cake.Issues.Tests/Testing/ResourceTempFileTests.cs
@@ -1,10 +1,6 @@
 ﻿namespace Cake.Issues.Tests.Testing
 {
     using System.IO;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class ResourceTempFileTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Tests/UriExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/UriExtensionsTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Tests
 {
-    using System;
-    using Cake.Issues.Testing;
-    using Shouldly;
-    using Xunit;
-
     public sealed class UriExtensionsTests
     {
         public sealed class TheAppendMethod

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -34,6 +34,10 @@
   <!-- Properties for test projects -->
   <Choose>
     <When Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+      <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+      </PropertyGroup>
+      
       <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
@@ -56,6 +60,17 @@
           <Version>4.2.1</Version>
         </PackageReference>
       </ItemGroup>
-    </When>
+
+      <ItemGroup>
+        <ProjectReference Include="..\Cake.Issues.Testing\Cake.Issues.Testing.csproj" />
+      </ItemGroup>
+
+      <ItemGroup>
+        <Using Include="Xunit" />
+        <Using Include="Shouldly" />
+        <Using Include="Cake.Testing" />
+        <Using Include="Cake.Issues.Testing" />
+      </ItemGroup>
+   </When>
   </Choose>
 </Project>


### PR DESCRIPTION
Use global usings and project reference to `Cake.Issues.Testing` for all test projects.