### PR TITLE
Define target frameworks in Directory.Build.props

### DIFF
--- a/nuspec/nuget/Cake.Issues.DocFx.nuspec
+++ b/nuspec/nuget/Cake.Issues.DocFx.nuspec
@@ -32,14 +32,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.DocFx.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.DocFx.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.DocFx.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.DocFx.xml" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.DocFx.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.DocFx.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.DocFx.xml" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.DocFx.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.DocFx.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.DocFx.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.DocFx.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.EsLint.nuspec
+++ b/nuspec/nuget/Cake.Issues.EsLint.nuspec
@@ -32,14 +32,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.EsLint.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.EsLint.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.EsLint.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.EsLint.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.EsLint.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.EsLint.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.EsLint.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.EsLint.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.EsLint.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.EsLint.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.EsLint.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.GitRepository.nuspec
+++ b/nuspec/nuget/Cake.Issues.GitRepository.nuspec
@@ -32,14 +32,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.GitRepository.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.GitRepository.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.GitRepository.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.GitRepository.xml" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.GitRepository.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.GitRepository.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.GitRepository.xml" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.GitRepository.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.GitRepository.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.GitRepository.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.GitRepository.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.InspectCode.nuspec
+++ b/nuspec/nuget/Cake.Issues.InspectCode.nuspec
@@ -32,14 +32,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.InspectCode.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.InspectCode.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.InspectCode.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.InspectCode.xml" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.InspectCode.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.InspectCode.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.InspectCode.xml" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.InspectCode.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.InspectCode.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.InspectCode.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.InspectCode.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Markdownlint.nuspec
+++ b/nuspec/nuget/Cake.Issues.Markdownlint.nuspec
@@ -32,14 +32,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Markdownlint.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.Markdownlint.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Markdownlint.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Markdownlint.xml" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.Markdownlint.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Markdownlint.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Markdownlint.xml" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.Markdownlint.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Markdownlint.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Markdownlint.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Markdownlint.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -32,23 +32,9 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.MsBuild.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.MsBuild.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.MsBuild.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.MsBuild.xml" target="lib\net6.0" />
-    <file src="net6.0\StructuredLogger.dll" target="lib\net6.0" />
-    <file src="net6.0\Microsoft.Build.Framework.dll" target="lib\net6.0" />
-    <file src="net6.0\Microsoft.Build.Utilities.Core.dll" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.MsBuild.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.MsBuild.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.MsBuild.xml" target="lib\net7.0" />
-    <file src="net7.0\StructuredLogger.dll" target="lib\net7.0" />
-    <file src="net7.0\Microsoft.Build.Framework.dll" target="lib\net7.0" />
-    <file src="net7.0\Microsoft.Build.Utilities.Core.dll" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.MsBuild.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.MsBuild.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.MsBuild.xml" target="lib\net8.0" />
-    <file src="net8.0\StructuredLogger.dll" target="lib\net8.0" />
-    <file src="net8.0\Microsoft.Build.Framework.dll" target="lib\net8.0" />
-    <file src="net8.0\Microsoft.Build.Utilities.Core.dll" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.MsBuild.*" target="lib" exclude="**\*.deps.json" />
+    <file src="Release\**\StructuredLogger.dll" target="lib" />
+    <file src="Release\**\Microsoft.Build.Framework.dll" target="lib" />
+    <file src="Release\**\Microsoft.Build.Utilities.Core.dll" target="lib" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.PullRequests.AppVeyor.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.AppVeyor.nuspec
@@ -30,14 +30,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.Ap
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.AppVeyor.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.PullRequests.AppVeyor.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.PullRequests.AzureDevOps.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.AzureDevOps.nuspec
@@ -31,14 +31,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.Az
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.PullRequests.AzureDevOps.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.AzureDevOps.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.AzureDevOps.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.AzureDevOps.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.AzureDevOps.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.AzureDevOps.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.AzureDevOps.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.AzureDevOps.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.AzureDevOps.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.PullRequests.AzureDevOps.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.PullRequests.GitHubActions.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.GitHubActions.nuspec
@@ -30,14 +30,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.Gi
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.PullRequests.GitHubActions.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.nuspec
@@ -30,14 +30,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.PullRequests.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.PullRequests.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.PullRequests.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.PullRequests.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.PullRequests.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.Console.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Console.nuspec
@@ -32,17 +32,7 @@ The addin requires Cake 1.2.0 or higher.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.Reporting.Console.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Reporting.Console.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Reporting.Console.xml" target="lib\net6.0" />
-    <file src="net6.0/Errata.dll" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.Reporting.Console.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Reporting.Console.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Reporting.Console.xml" target="lib\net7.0" />
-    <file src="net7.0/Errata.dll" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.Reporting.Console.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Reporting.Console.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Reporting.Console.xml" target="lib\net8.0" />
-    <file src="net8.0/Errata.dll" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Reporting.Console*" target="lib" exclude="**\*.deps.json" />
+    <file src="Release\**\Errata.dll" target="lib" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
@@ -30,7 +30,8 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.Gener
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="**\*.dll" target="lib" exclude="**\*CodeAnalysis*.dll;**\Cake.Core.dll;**\Cake.Issues.dll;**\Cake.Issues.Reporting.dll;**\System.*.dll" />
-    <file src="**\Cake.Issues.Reporting.Generic.xml" target="lib" />
+    <file src="Release\**\Cake.Issues.Reporting.Generic.*" target="lib" exclude="**\*.deps.json" />
+    <file src="Release\**\Gazorator.dll" target="lib" />
+    <file src="Release\**\Microsoft.AspNetCore.Razor.Language.dll" target="lib" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Sarif.nuspec
@@ -30,17 +30,7 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.Sarif
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Reporting.Sarif.xml" target="lib\net6.0" />
-    <file src="net6.0/Sarif.dll" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Reporting.Sarif.xml" target="lib\net7.0" />
-    <file src="net7.0/Sarif.dll" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Reporting.Sarif.xml" target="lib\net8.0" />
-    <file src="net8.0/Sarif.dll" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Reporting.Sarif.*" target="lib" exclude="**\*.deps.json" />
+    <file src="Release\**\Sarif.dll" target="lib" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.nuspec
@@ -30,14 +30,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.Reporting.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.Reporting.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.Reporting.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.Reporting.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.Reporting.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.Reporting.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.Reporting.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.Reporting.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.Reporting.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Reporting.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Issues.Sarif.nuspec
@@ -32,17 +32,7 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Sarif.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.Sarif.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Sarif.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Sarif.xml" target="lib\net6.0" />
-    <file src="net6.0/Sarif.dll" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.Sarif.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Sarif.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Sarif.xml" target="lib\net7.0" />
-    <file src="net7.0/Sarif.dll" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.Sarif.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Sarif.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Sarif.xml" target="lib\net8.0" />
-    <file src="net8.0/Sarif.dll" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Sarif.*" target="lib" exclude="**\*.deps.json" />
+    <file src="Release\**\Sarif.dll" target="lib" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Terraform.nuspec
+++ b/nuspec/nuget/Cake.Issues.Terraform.nuspec
@@ -32,14 +32,6 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Terraform.
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0/Cake.Issues.Terraform.dll" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Terraform.pdb" target="lib\net6.0" />
-    <file src="net6.0/Cake.Issues.Terraform.xml" target="lib\net6.0" />
-    <file src="net7.0/Cake.Issues.Terraform.dll" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Terraform.pdb" target="lib\net7.0" />
-    <file src="net7.0/Cake.Issues.Terraform.xml" target="lib\net7.0" />
-    <file src="net8.0/Cake.Issues.Terraform.dll" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Terraform.pdb" target="lib\net8.0" />
-    <file src="net8.0/Cake.Issues.Terraform.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Terraform.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.Testing.nuspec
+++ b/nuspec/nuget/Cake.Issues.Testing.nuspec
@@ -21,14 +21,6 @@ Common helpers for testing add-ins based on Cake.Issues
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.Testing.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.Testing.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.Testing.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.Testing.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.Testing.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.Testing.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.Testing.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.Testing.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.Testing.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.Testing.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.Issues.nuspec
+++ b/nuspec/nuget/Cake.Issues.nuspec
@@ -28,14 +28,6 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="net6.0\Cake.Issues.dll" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.pdb" target="lib\net6.0" />
-    <file src="net6.0\Cake.Issues.xml" target="lib\net6.0" />
-    <file src="net7.0\Cake.Issues.dll" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.pdb" target="lib\net7.0" />
-    <file src="net7.0\Cake.Issues.xml" target="lib\net7.0" />
-    <file src="net8.0\Cake.Issues.dll" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.pdb" target="lib\net8.0" />
-    <file src="net8.0\Cake.Issues.xml" target="lib\net8.0" />
+    <file src="Release\**\Cake.Issues.*" target="lib" exclude="**\*.deps.json" />
   </files>
 </package>

--- a/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
+++ b/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.DocFx addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
+++ b/src/Cake.Issues.DocFx/Cake.Issues.DocFx.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>DocFx support for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
+++ b/src/Cake.Issues.EsLint.Tests/Cake.Issues.EsLint.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Description>Tests for the Cake.Issues.EsLint addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
+++ b/src/Cake.Issues.EsLint/Cake.Issues.EsLint.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>EsLint support for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
+++ b/src/Cake.Issues.GitRepository.Tests/Cake.Issues.GitRepository.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.GitRepository addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
+++ b/src/Cake.Issues.GitRepository/Cake.Issues.GitRepository.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Git repository linting support for the Cake.Issues addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
+++ b/src/Cake.Issues.InspectCode.Tests/Cake.Issues.InspectCode.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.InspectCode addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
+++ b/src/Cake.Issues.InspectCode/Cake.Issues.InspectCode.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>JetBrains Inspect Code support for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
   

--- a/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
+++ b/src/Cake.Issues.Markdownlint.Tests/Cake.Issues.Markdownlint.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.Markdownlint addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
+++ b/src/Cake.Issues.Markdownlint/Cake.Issues.Markdownlint.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Markdownlint support for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
+++ b/src/Cake.Issues.MsBuild.Tests/Cake.Issues.MsBuild.Tests.csproj
@@ -1,9 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="Testfiles\**\*" />
   </ItemGroup>
@@ -16,5 +11,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Cake.Issues.MsBuild\Cake.Issues.MsBuild.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
+++ b/src/Cake.Issues.MsBuild/Cake.Issues.MsBuild.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>MsBuild support for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor.Tests/Cake.Issues.PullRequests.AppVeyor.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Description>Tests for the Cake.Issues.PullRequests.AppVeyor addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
+++ b/src/Cake.Issues.PullRequests.AppVeyor/Cake.Issues.PullRequests.AppVeyor.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for writing code analyzer or linter issues to AppVeyor</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Cake.Issues.PullRequests.AzureDevOps.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Cake.Issues.PullRequests.AzureDevOps.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.PullRequests.AzureDevOps addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.AzureDevOps/Cake.Issues.PullRequests.AzureDevOps.csproj
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/Cake.Issues.PullRequests.AzureDevOps.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Azure DevOps support for the Cake.Issues addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.GitHubActions.Tests/Cake.Issues.PullRequests.GitHubActions.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.GitHubActions.Tests/Cake.Issues.PullRequests.GitHubActions.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Description>Tests for the Cake.Issues.PullRequests.GitHubActions addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.GitHubActions/Cake.Issues.PullRequests.GitHubActions.csproj
+++ b/src/Cake.Issues.PullRequests.GitHubActions/Cake.Issues.PullRequests.GitHubActions.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for writing code analyzer or linter issues to GitHub Actions</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.Tests/Cake.Issues.PullRequests.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.PullRequests addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
+++ b/src/Cake.Issues.PullRequests/Cake.Issues.PullRequests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for the Cake build automation system for writing code analyzer or linter issues as comments to pull requests</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Console.Tests/Cake.Issues.Reporting.Console.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Console.Tests/Cake.Issues.Reporting.Console.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.Reporting.Console addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
+++ b/src/Cake.Issues.Reporting.Console/Cake.Issues.Reporting.Console.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Support for reporting issues to the console for the Cake.Issues addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.Reporting.Generic addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Support for creating issue reports in any text based format (HTML, Markdown, ...) from the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/Cake.Issues.Reporting.Sarif.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Description>Tests for the Cake.Issues.Reporting.Sarif addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Support for creating SARIF compatible files for the Cake.Issues addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Tests/Cake.Issues.Reporting.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.Reporting addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
+++ b/src/Cake.Issues.Reporting/Cake.Issues.Reporting.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for the Cake build automation system for creating reports for issues from any code analyzer or linter</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Sarif.Tests/Cake.Issues.Sarif.Tests.csproj
+++ b/src/Cake.Issues.Sarif.Tests/Cake.Issues.Sarif.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues.Sarif addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Sarif/Cake.Issues.Sarif.csproj
+++ b/src/Cake.Issues.Sarif/Cake.Issues.Sarif.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Support for SARIF compatible files for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Terraform.Tests/Cake.Issues.Terraform.Tests.csproj
+++ b/src/Cake.Issues.Terraform.Tests/Cake.Issues.Terraform.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <Description>Tests for the Cake.Issues.Terraform addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Terraform/Cake.Issues.Terraform.csproj
+++ b/src/Cake.Issues.Terraform/Cake.Issues.Terraform.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Terraform support for the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
+++ b/src/Cake.Issues.Testing/Cake.Issues.Testing.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Common helpers for testing addins based on Cake.Issues</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
+++ b/src/Cake.Issues.Tests/Cake.Issues.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Tests for the Cake.Issues addin</Description>
   </PropertyGroup>
 

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Description>Addin for reading code analyzer or linter issues for the Cake build automation system</Description>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <!-- Properties for all projects -->
   <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Authors>Cake Issues contributors</Authors>
     <Copyright>Copyright © Cake Issues contributors</Copyright>


### PR DESCRIPTION
Define target frameworks in `Directory.Build.props` instead of individual project files.

Also runs all unit tests agains all supported .NET versions.

Fixes #591