### PR TITLE
Fix typos in identifiers

### DIFF
--- a/src/Cake.Issues.PullRequests.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/IIssueExtensionsTests.cs
@@ -2,7 +2,7 @@
 {
     public sealed class IIssueExtensionsTests
     {
-        public sealed class TheSortWithDefaultPriorizationMethod
+        public sealed class TheSortWithDefaultPrioritizationMethod
         {
             [Fact]
             public void Should_Throw_If_Issues_Are_Null()
@@ -13,7 +13,7 @@
                 // When
                 var result =
                     Record.Exception(() =>
-                        issues.SortWithDefaultPriorization());
+                        issues.SortWithDefaultPrioritization());
 
                 // Then
                 result.IsArgumentNullException("issues");
@@ -45,7 +45,7 @@
                     };
 
                 // When
-                var result = issues.SortWithDefaultPriorization().ToList();
+                var result = issues.SortWithDefaultPrioritization().ToList();
 
                 // Then
                 result.First().ShouldBe(issue2);
@@ -77,7 +77,7 @@
                     };
 
                 // When
-                var result = issues.SortWithDefaultPriorization().ToList();
+                var result = issues.SortWithDefaultPrioritization().ToList();
 
                 // Then
                 result.First().ShouldBe(issue2);
@@ -110,7 +110,7 @@
                     };
 
                 // When
-                var result = issues.SortWithDefaultPriorization().ToList();
+                var result = issues.SortWithDefaultPrioritization().ToList();
 
                 // Then
                 result.First().ShouldBe(issue2);

--- a/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
+++ b/src/Cake.Issues.PullRequests.Tests/OrchestratorTests.cs
@@ -101,7 +101,7 @@ namespace Cake.Issues.PullRequests.Tests
             }
 
             [Fact]
-            public void Should_Not_Throw_If_Issues_Are_Empry()
+            public void Should_Not_Throw_If_Issues_Are_Empty()
             {
                 // Given
                 var fixture = new OrchestratorForIssuesFixture();
@@ -981,7 +981,7 @@ namespace Cake.Issues.PullRequests.Tests
         public sealed class TheRunMethodWithCheckingCommitIdCapability
         {
             [Fact]
-            public void Should_Skip_Posting_If_Commit_Is_Outdate()
+            public void Should_Skip_Posting_If_Commit_Is_Outdated()
             {
                 // Given
                 var issueToPost =

--- a/src/Cake.Issues.PullRequests/IIssueExtensions.cs
+++ b/src/Cake.Issues.PullRequests/IIssueExtensions.cs
@@ -18,7 +18,7 @@
         /// </summary>
         /// <param name="issues">Issues to be sorted.</param>
         /// <returns>The sorted issues.</returns>
-        public static IEnumerable<IIssue> SortWithDefaultPriorization(this IEnumerable<IIssue> issues)
+        public static IEnumerable<IIssue> SortWithDefaultPrioritization(this IEnumerable<IIssue> issues)
         {
             issues.NotNull(nameof(issues));
 

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -229,7 +229,7 @@ namespace Cake.Issues.PullRequests
                     var countBefore = group.Count();
                     var issuesFiltered =
                         group
-                            .SortWithDefaultPriorization()
+                            .SortWithDefaultPrioritization()
                             .Take(this.settings.MaxIssuesToPostForEachIssueProvider.Value)
                             .ToList();
                     var issuesFilteredCount = countBefore - issuesFiltered.Count;
@@ -274,7 +274,7 @@ namespace Cake.Issues.PullRequests
 
                 var newIssuesForProviderType =
                     result.Where(p => p.ProviderType == currentProviderType)
-                        .SortWithDefaultPriorization()
+                        .SortWithDefaultPrioritization()
                         .ToArray();
                 if (newIssuesForProviderType.Length <= currentProviderTypeMaxLimit)
                 {
@@ -305,7 +305,7 @@ namespace Cake.Issues.PullRequests
                 var countBefore = result.Count;
                 result =
                     result
-                        .SortWithDefaultPriorization()
+                        .SortWithDefaultPrioritization()
                         .Take(this.settings.MaxIssuesToPost.Value)
                         .ToList();
                 var issuesFilteredCount = countBefore - result.Count;
@@ -353,7 +353,7 @@ namespace Cake.Issues.PullRequests
 
                 var newIssuesForProviderType =
                     result.Where(p => p.ProviderType == currentProviderType)
-                        .SortWithDefaultPriorization()
+                        .SortWithDefaultPrioritization()
                         .ToArray();
                 if (newIssuesForProviderType.Length <= maxIssuesLeftToTakeForProviderType)
                 {
@@ -386,7 +386,7 @@ namespace Cake.Issues.PullRequests
                 var countBefore = result.Count;
                 result =
                     result
-                        .SortWithDefaultPriorization()
+                        .SortWithDefaultPrioritization()
                         .Take(maxIssuesToPostInThisRun)
                         .ToList();
                 var issuesFilteredCount = countBefore - result.Count;

--- a/src/Cake.Issues.Reporting.Console/IssueDiagnostic.cs
+++ b/src/Cake.Issues.Reporting.Console/IssueDiagnostic.cs
@@ -102,13 +102,13 @@
 
             var location = new Location(issue.Line.Value, issue.Column.Value);
 
-            var lenght = 0;
+            var length = 0;
             if (issue.EndColumn.HasValue)
             {
-                lenght = issue.EndColumn.Value - issue.Column.Value;
+                length = issue.EndColumn.Value - issue.Column.Value;
             }
 
-            return (location, lenght);
+            return (location, length);
         }
     }
 }

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
@@ -44,7 +44,7 @@
             }
 
             [Fact]
-            public void Should_Read_Issue_Correct_For_Recomended_File_Without_Source()
+            public void Should_Read_Issue_Correct_For_Recommended_File_Without_Source()
             {
                 // Given
                 var fixture = new SarifIssuesProviderFixture("recommended-without-source.sarif");
@@ -67,7 +67,7 @@
             }
 
             [Fact]
-            public void Should_Read_Issue_Correct_For_Recomended_File_With_Source()
+            public void Should_Read_Issue_Correct_For_Recommended_File_With_Source()
             {
                 // Given
                 var fixture = new SarifIssuesProviderFixture("recommended-with-source.sarif");


### PR DESCRIPTION
Fixes typos in identifiers. All identifiers are internal and therefor non-breaking changes.