### PR TITLE
Remove no longer required test service

### DIFF
--- a/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
+++ b/src/Cake.Issues.DocFx.Tests/Cake.Issues.DocFx.Tests.csproj
@@ -12,10 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Cake.Issues.DocFx\Cake.Issues.DocFx.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove service for test projects which is no longer required in current Visual Studio versions 