### PR TITLE
Throw exception if null is passed to GetHashCode

### DIFF
--- a/src/Cake.Issues.Tests/IIssueComparerTests.cs
+++ b/src/Cake.Issues.Tests/IIssueComparerTests.cs
@@ -5,7 +5,7 @@
         public sealed class TheCtorWithCompareOnlyPersistentPropertiesSetToFalse
         {
             [Fact]
-            public void Should_Return_False_If_First_Issue_Is_Null()
+            public void Should_Throw_If_First_Issue_Is_Null()
             {
                 // Given
                 const IIssue issue1 = null;
@@ -14,12 +14,16 @@
                         .NewIssue("message", "providerType", "providerName")
                         .Create();
 
-                // When / Then
-                CompareIssues(issue1, issue2, false);
+                // When
+                var result = Record.Exception(() =>
+                    CompareIssues(issue1, issue2, false));
+
+                // Then
+                result.IsArgumentNullException("obj");
             }
 
             [Fact]
-            public void Should_Return_False_If_Second_Issue_Is_Null()
+            public void Should_Throw_If_Second_Issue_Is_Null()
             {
                 // Given
                 var issue1 =
@@ -28,8 +32,27 @@
                         .Create();
                 const IIssue issue2 = null;
 
-                // When / Then
-                CompareIssues(issue1, issue2, false);
+                // When
+                var result = Record.Exception(() =>
+                    CompareIssues(issue1, issue2, false));
+
+                // Then
+                result.IsArgumentNullException("obj");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Both_Are_Null()
+            {
+                // Given
+                const IIssue issue1 = null;
+                const IIssue issue2 = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    CompareIssues(issue1, issue2, true));
+
+                // Then
+                result.IsArgumentNullException("obj");
             }
 
             [Theory]
@@ -414,17 +437,6 @@
                         .NewIssue("message", "providerType", "providerName")
                         .Create();
                 var issue2 = issue1;
-
-                // When / Then
-                CompareIssues(issue1, issue2, true);
-            }
-
-            [Fact]
-            public void Should_Return_True_If_Both_Are_Null()
-            {
-                // Given
-                const IIssue issue1 = null;
-                const IIssue issue2 = null;
 
                 // When / Then
                 CompareIssues(issue1, issue2, true);
@@ -920,7 +932,7 @@
         public sealed class TheCtorWithCompareOnlyPersistentPropertiesSetToTrue
         {
             [Fact]
-            public void Should_Return_False_If_First_Issue_Is_Null()
+            public void Should_Throw_If_First_Issue_Is_Null()
             {
                 // Given
                 const IIssue issue1 = null;
@@ -929,12 +941,16 @@
                         .NewIssue("message", "providerType", "providerName")
                         .Create();
 
-                // When / Then
-                CompareIssues(issue1, issue2, false);
+                // When
+                var result = Record.Exception(() =>
+                    CompareIssues(issue1, issue2, false));
+
+                // Then
+                result.IsArgumentNullException("obj");
             }
 
             [Fact]
-            public void Should_Return_False_If_Second_Issue_Is_Null()
+            public void Should_Throw_If_Second_Issue_Is_Null()
             {
                 // Given
                 var issue1 =
@@ -943,8 +959,27 @@
                         .Create();
                 const IIssue issue2 = null;
 
-                // When / Then
-                CompareIssues(issue1, issue2, false);
+                // When
+                var result = Record.Exception(() =>
+                    CompareIssues(issue1, issue2, false));
+
+                // Then
+                result.IsArgumentNullException("obj");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Both_Are_Null()
+            {
+                // Given
+                const IIssue issue1 = null;
+                const IIssue issue2 = null;
+
+                // When
+                var result = Record.Exception(() =>
+                    CompareIssues(issue1, issue2, true));
+
+                // Then
+                result.IsArgumentNullException("obj");
             }
 
             [Theory]
@@ -1200,17 +1235,6 @@
                         .NewIssue("message", "providerType", "providerName")
                         .Create();
                 var issue2 = issue1;
-
-                // When / Then
-                CompareIssues(issue1, issue2, true);
-            }
-
-            [Fact]
-            public void Should_Return_True_If_Both_Are_Null()
-            {
-                // Given
-                const IIssue issue1 = null;
-                const IIssue issue2 = null;
 
                 // When / Then
                 CompareIssues(issue1, issue2, true);

--- a/src/Cake.Issues/IIssueComparer.cs
+++ b/src/Cake.Issues/IIssueComparer.cs
@@ -88,10 +88,7 @@
         /// <inheritdoc/>
         public int GetHashCode(IIssue obj)
         {
-            if (obj is null)
-            {
-                return 0;
-            }
+            obj.NotNull(nameof(obj));
 
             if (compareOnlyPersistentProperties)
             {


### PR DESCRIPTION
Throw exception if null is passed to `GetHashCode` instead of returning `0` since throwing is the [documented behavior](https://learn.microsoft.com/en-us/dotnet/api/system.collections.iequalitycomparer.gethashcode?view=net-8.0#exceptions).