### PR TITLE
Only report code coverage for .NET 8

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -126,6 +126,41 @@ BuildParameters.Tasks.InspectCodeTask
     })
 );
 
+// Upload only .NET 8 coverage results to avoid issues with files being too large
+((CakeTask)BuildParameters.Tasks.UploadCodecovReportTask.Task).Actions.Clear();
+BuildParameters.Tasks.UploadCodecovReportTask
+    .WithCriteria(() => BuildParameters.IsMainRepository, "Skipping because not running from the main repository")
+    .WithCriteria(() => BuildParameters.ShouldRunCodecov, "Skipping because uploading to codecov is disabled")
+    .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on appveyor")
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.CodecovGlobalTool : ToolSettings.CodecovTool, () => {
+        var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.net8.0.opencover.xml");
+        if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
+        {
+            coverageFiles += BuildParameters.Paths.Files.TestCoverageOutputFilePath;
+        }
+
+        if (coverageFiles.Any())
+        {
+            var settings = new CodecovSettings {
+                Files = coverageFiles.Select(f => f.FullPath),
+                Required = true
+            };
+            if (buildVersion != null &&
+                !string.IsNullOrEmpty(buildVersion.FullSemVersion) &&
+                BuildParameters.IsRunningOnAppVeyor)
+            {
+                // Required to work correctly with appveyor because environment changes isn't detected until cake is done running.
+                var localBuildVersion = string.Format("{0}.build.{1}",
+                    buildVersion.FullSemVersion,
+                    BuildSystem.AppVeyor.Environment.Build.Number);
+                settings.EnvironmentVariables = new Dictionary<string, string> { { "APPVEYOR_BUILD_VERSION", localBuildVersion }};
+            }
+
+            Codecov(settings);
+        }
+    })
+);
+
 //*************************************************************************************************
 // Execution
 //*************************************************************************************************


### PR DESCRIPTION
If we send code coverage for .NET 6, .NET 7 and .NET 8 to CodeCov we run into issues with the files being to big. PR overrides build script to only report code coverage for .NET 8.