### PR TITLE
(GH-599) Don't print diagnostics if ShowDiagnostics is set to false

### DIFF
--- a/src/Cake.Issues.Reporting.Console/ConsoleIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Console/ConsoleIssueReportGenerator.cs
@@ -32,7 +32,7 @@
         protected override FilePath InternalCreateReport(IEnumerable<IIssue> issues)
         {
             var enumeratedIssues = issues.ToList();
-            if (this.consoleIssueReportFormatSettings.ShowProviderSummary)
+            if (this.consoleIssueReportFormatSettings.ShowDiagnostics)
             {
                 // Filter to issues from existing files
                 var diagnosticIssues =


### PR DESCRIPTION
Fixes check for printing of diagnostics in Cake.Issues.Reporting.Console addin.

Fixes #599