### PR TITLE
Remove ReSharper

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -16,6 +16,7 @@ BuildParameters.SetParameters(
     appVeyorAccountName: "cakecontrib",
     shouldUseDeterministicBuilds: true,
     shouldGenerateDocumentation: false, // Documentation is generated from Cake.Issues.Website
+    shouldRunInspectCode: false,
     shouldRunCoveralls: false,  // Disabled because it's currently failing
     shouldPostToGitter: false); // Disabled because it's currently failing
 
@@ -23,7 +24,6 @@ BuildParameters.PrintParameters(Context);
 
 ToolSettings.SetToolPreprocessorDirectives(
     gitReleaseManagerGlobalTool: "#tool dotnet:?package=GitReleaseManager.Tool&version=0.17.0",
-    reSharperTools: "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2024.1.2",
     nugetTool: "#tool nuget:?package=NuGet.CommandLine&version=6.9.1"
 );
 

--- a/src/Cake.Issues.DocFx/LogEntryDataContract.cs
+++ b/src/Cake.Issues.DocFx/LogEntryDataContract.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
-namespace Cake.Issues.DocFx
+﻿namespace Cake.Issues.DocFx
 {
     using System.Runtime.Serialization;
 

--- a/src/Cake.Issues.EsLint/BaseEsLintLogFileFormat.cs
+++ b/src/Cake.Issues.EsLint/BaseEsLintLogFileFormat.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.EsLint
+﻿namespace Cake.Issues.EsLint
 {
     using Cake.Core.Diagnostics;
 

--- a/src/Cake.Issues.EsLint/EsLintDataContracts.cs
+++ b/src/Cake.Issues.EsLint/EsLintDataContracts.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
-namespace Cake.Issues.EsLint
+﻿namespace Cake.Issues.EsLint
 {
     using System.Runtime.Serialization;
 

--- a/src/Cake.Issues.EsLint/EsLintIssuesAliases.cs
+++ b/src/Cake.Issues.EsLint/EsLintIssuesAliases.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.EsLint
+﻿namespace Cake.Issues.EsLint
 {
     using Cake.Core.Annotations;
 

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesProvider.cs
@@ -213,10 +213,8 @@
             settings.Arguments.Add("grep -IL .");
             var emptyFiles = this.runner.RunCommand(settings);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             if (emptyFiles != null && emptyFiles.Any())
             {
-                // ReSharper disable once PossibleMultipleEnumeration
                 textFilesFromRepository = textFilesFromRepository.Concat(emptyFiles);
             }
 

--- a/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
+++ b/src/Cake.Issues.GitRepository/GitRepositoryIssuesSettings.cs
@@ -10,21 +10,18 @@
         /// binary files not tracked by Git LFS.
         /// Requires Git and Git-LFS to be available through Cake tool resolution.
         /// </summary>
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public bool CheckBinaryFilesTrackedByLfs { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the repository should be checked for
         /// files path longer than <see cref="MaxFilePathLength"/>.
         /// </summary>
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public bool CheckFilesPathLength { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the maximum allowed length of file paths if
         /// <see cref="CheckFilesPathLength"/> is enabled.
         /// </summary>
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public int MaxFilePathLength { get; set; }
     }
 }

--- a/src/Cake.Issues.InspectCode.Tests/ExtensionsTests.cs
+++ b/src/Cake.Issues.InspectCode.Tests/ExtensionsTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.InspectCode.Tests
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class ExtensionsTests
     {
         public sealed class TheToUriExtension

--- a/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesProviderTests.cs
+++ b/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesProviderTests.cs
@@ -2,7 +2,6 @@
 {
     using System.Runtime.InteropServices;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class InspectCodeIssuesProviderTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesSettingsTests.cs
+++ b/src/Cake.Issues.InspectCode.Tests/InspectCodeIssuesSettingsTests.cs
@@ -2,7 +2,6 @@
 {
     using Cake.Core.IO;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class InspectCodeIssuesSettingsTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Markdownlint/BaseMarkdownlintLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/BaseMarkdownlintLogFileFormat.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.Markdownlint
+﻿namespace Cake.Issues.Markdownlint
 {
     using Cake.Core.Diagnostics;
 

--- a/src/Cake.Issues.Markdownlint/IssueDataContract.cs
+++ b/src/Cake.Issues.Markdownlint/IssueDataContract.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
-namespace Cake.Issues.Markdownlint
+﻿namespace Cake.Issues.Markdownlint
 {
     using System.Runtime.Serialization;
 

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliJsonLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliJsonLogFileFormat.cs
@@ -106,7 +106,6 @@
 #pragma warning disable CS0649 // Field 'field' is never assigned to, and will always have its default value 'value'
 
         [DataContract]
-        [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Following file format")]
         private class LogFileEntry
         {
             [DataMember]

--- a/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.Markdownlint
+﻿namespace Cake.Issues.Markdownlint
 {
     using Cake.Core.Annotations;
 

--- a/src/Cake.Issues.MsBuild/MsBuildIssuesAliases.cs
+++ b/src/Cake.Issues.MsBuild/MsBuildIssuesAliases.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.MsBuild
+﻿namespace Cake.Issues.MsBuild
 {
     using Cake.Core.Annotations;
 

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemSettingsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemSettingsTests.cs
@@ -2,7 +2,6 @@
 {
     using Cake.AzureDevOps.Authentication;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsPullRequestSystemSettingsTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/AzureDevOpsPullRequestSystemTests.cs
@@ -3,7 +3,6 @@
     using Cake.AzureDevOps.Authentication;
     using Cake.Core.Diagnostics;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsPullRequestSystemTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsCheckingCommitIdCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsCheckingCommitIdCapabilityTests.cs
@@ -4,7 +4,6 @@
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
     using NSubstitute;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsCheckingCommitIdCapabilityTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsDiscussionThreadsCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsDiscussionThreadsCapabilityTests.cs
@@ -4,7 +4,6 @@
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
     using NSubstitute;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsDiscussionThreadsCapabilityTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsFilteringByModifiedFilesCapabilityTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/AzureDevOpsFilteringByModifiedFilesCapabilityTests.cs
@@ -4,7 +4,6 @@
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
     using NSubstitute;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class AzureDevOpsFilteringByModifiedFilesCapabilityTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentExtensionsTests.cs
@@ -3,7 +3,6 @@
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class CommentExtensionsTests
     {
         public sealed class TheToPullRequestDiscussionCommentExtension

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentThreadStatusExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/CommentThreadStatusExtensionsTests.cs
@@ -3,7 +3,6 @@
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class CommentThreadStatusExtensionsTests
     {
         public sealed class TheToPullRequestDiscussionStatusExtension

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/GitPullRequestCommentThreadExtensionsTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/Capabilities/GitPullRequestCommentThreadExtensionsTests.cs
@@ -3,7 +3,6 @@
     using Cake.AzureDevOps.Repos.PullRequest.CommentThread;
     using Cake.Issues.PullRequests.AzureDevOps.Capabilities;
 
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class GitPullRequestCommentThreadExtensionsTests
     {
         public sealed class TheToPullRequestDiscussionThreadExtension

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/ContentProviderTests.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/ContentProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cake.Issues.PullRequests.AzureDevOps.Tests
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
     public sealed class ContentProviderTests
     {
         public sealed class TheGetContentMethod

--- a/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystem.cs
@@ -78,7 +78,6 @@
         /// <inheritdoc/>
         protected override void InternalPostDiscussionThreads(IEnumerable<IIssue> issues, string commentSource)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
             if (!this.ValidatePullRequest())
@@ -86,7 +85,6 @@
                 return;
             }
 
-            // ReSharper disable once PossibleMultipleEnumeration
             var threads = this.CreateDiscussionThreads(issues, commentSource).ToList();
 
             if (threads.Count == 0)
@@ -143,7 +141,6 @@
             IEnumerable<IIssue> issues,
             string commentSource)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
             if (this.azureDevOpsPullRequest.CodeReviewId <= 0)
@@ -161,13 +158,11 @@
             // Filter issues not related to a file.
             if (!this.settings.ReportIssuesNotRelatedToAFile)
             {
-                // ReSharper disable once PossibleMultipleEnumeration
                 issues = issues.Where(x => x.AffectedFileRelativePath != null);
             }
 
             var result = new List<AzureDevOpsPullRequestCommentThread>();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             foreach (var issue in issues)
             {
                 var changeTrackingId =
@@ -273,11 +268,9 @@
 
         private int TryGetCodeFlowChangeTrackingId(IEnumerable<AzureDevOpsPullRequestIterationChange> changes, FilePath path)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             changes.NotNull();
             path.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             var change =
                 changes
                     .Where(x => x.ItemPath != null && x.ItemPath.FullPath == "/" + path)

--- a/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemAliases.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemAliases.cs
@@ -7,7 +7,6 @@
     /// Contains functionality related to writing code analysis issues to Azure DevOps pull requests.
     /// </summary>
     [CakeAliasCategory(IssuesAliasConstants.MainCakeAliasCategory)]
-    [SuppressMessage("ReSharper", "RedundantTypeDeclarationBody", Justification = "Fixing will crash StyleCop")]
     public static partial class AzureDevOpsPullRequestSystemAliases
     {
     }

--- a/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemSettings.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemSettings.cs
@@ -71,7 +71,6 @@
         /// is still up-to-date before posting comments.
         /// Default value is <c>true</c>.
         /// </summary>
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public bool CheckCommitId { get; set; } = true;
 
         /// <summary>
@@ -79,7 +78,6 @@
         /// resolved oder reopened.
         /// Default value is <c>true</c>.
         /// </summary>
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public bool ManageDiscussionThreadStatus { get; set; } = true;
 
         /// <summary>
@@ -87,7 +85,6 @@
         /// as comments or not.
         /// Default value is <c>false</c>.
         /// </summary>
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public bool ReportIssuesNotRelatedToAFile { get; set; }
     }
 }

--- a/src/Cake.Issues.PullRequests.AzureDevOps/Capabilities/AzureDevOpsDiscussionThreadsCapability.cs
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/Capabilities/AzureDevOpsDiscussionThreadsCapability.cs
@@ -50,10 +50,8 @@
         /// <inheritdoc />
         protected override void InternalResolveDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             threads.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             foreach (var thread in threads)
             {
                 this.PullRequestSystem.AzureDevOpsPullRequest.ResolveCommentThread(thread.Id);
@@ -63,10 +61,8 @@
         /// <inheritdoc />
         protected override void InternalReopenDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             threads.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             foreach (var thread in threads)
             {
                 this.PullRequestSystem.AzureDevOpsPullRequest.ActivateCommentThread(thread.Id);

--- a/src/Cake.Issues.PullRequests.Tests/FakeDiscussionThreadsCapability.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakeDiscussionThreadsCapability.cs
@@ -23,10 +23,8 @@
             IEnumerable<IPullRequestDiscussionThread> discussionThreads)
             : base(log, pullRequestSystem)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             discussionThreads.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.discussionThreads.AddRange(discussionThreads);
         }
 
@@ -64,20 +62,16 @@
         /// <inheritdoc />
         protected override void InternalResolveDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             threads.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.resolvedThreads.AddRange(threads);
         }
 
         /// <inheritdoc />
         protected override void InternalReopenDiscussionThreads(IEnumerable<IPullRequestDiscussionThread> threads)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             threads.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.reopenedThreads.AddRange(threads);
         }
     }

--- a/src/Cake.Issues.PullRequests.Tests/FakeFilteringByModifiedFilesCapability.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakeFilteringByModifiedFilesCapability.cs
@@ -22,10 +22,8 @@
             IEnumerable<FilePath> modifiedFiles)
             : base(log, pullRequestSystem)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             modifiedFiles.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.modifiedFiles.AddRange(modifiedFiles);
         }
 

--- a/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.Tests/FakePullRequestSystem.cs
@@ -59,10 +59,8 @@
         /// <inheritdoc />
         protected override void InternalPostDiscussionThreads(IEnumerable<IIssue> issues, string commentSource)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.postedIssues.AddRange(issues);
         }
     }

--- a/src/Cake.Issues.PullRequests/Aliases.cs
+++ b/src/Cake.Issues.PullRequests/Aliases.cs
@@ -45,10 +45,8 @@
             pullRequestSystem.NotNull();
             repositoryRoot.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNullOrEmptyElement();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return
                 context.ReportIssuesToPullRequest(
                     issues,
@@ -96,7 +94,6 @@
             pullRequestSystem.NotNull();
             settings.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNullOrEmptyElement();
 
             var orchestrator =
@@ -104,7 +101,6 @@
                     context.Log,
                     pullRequestSystem);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return orchestrator.Run(issues, settings);
         }
 
@@ -193,10 +189,8 @@
             pullRequestSystem.NotNull();
             repositoryRoot.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return
                 context.ReportIssuesToPullRequest(
                     issueProviders,
@@ -301,7 +295,6 @@
             pullRequestSystem.NotNull();
             settings.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
             var orchestrator =
@@ -309,7 +302,6 @@
                     context.Log,
                     pullRequestSystem);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return orchestrator.Run(issueProviders, settings);
         }
     }

--- a/src/Cake.Issues.PullRequests/IPullRequestSystemCapability.cs
+++ b/src/Cake.Issues.PullRequests/IPullRequestSystemCapability.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.PullRequests
+﻿namespace Cake.Issues.PullRequests
 {
     /// <summary>
     /// Interface for all optional pull request system capabilities.

--- a/src/Cake.Issues.PullRequests/IReportIssuesToPullRequestFromIssueProviderSettings.cs
+++ b/src/Cake.Issues.PullRequests/IReportIssuesToPullRequestFromIssueProviderSettings.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.PullRequests
+﻿namespace Cake.Issues.PullRequests
 {
     /// <summary>
     /// Interface for settings affecting how issues read from issue providers are reported to pull requests.

--- a/src/Cake.Issues.PullRequests/IssueFilterer.cs
+++ b/src/Cake.Issues.PullRequests/IssueFilterer.cs
@@ -49,12 +49,10 @@ namespace Cake.Issues.PullRequests
             IDictionary<IIssue, IssueCommentInfo> issueComments,
             IReadOnlyCollection<IPullRequestDiscussionThread> existingThreads)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
             this.log.Verbose("Filtering issues before posting...");
 
-            // ReSharper disable once PossibleMultipleEnumeration
             var result = this.FilterIssuesByPath(issues as IList<IIssue> ?? issues.ToList());
 
             if (issueComments != null)

--- a/src/Cake.Issues.PullRequests/Orchestrator.cs
+++ b/src/Cake.Issues.PullRequests/Orchestrator.cs
@@ -44,11 +44,9 @@ namespace Cake.Issues.PullRequests
             IEnumerable<IIssueProvider> issueProviders,
             IReportIssuesToPullRequestFromIssueProviderSettings settings)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
             settings.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             var issuesReader =
                 new IssuesReader(this.log, issueProviders, settings);
 

--- a/src/Cake.Issues.PullRequests/PullRequestDiscussionThread.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestDiscussionThread.cs
@@ -26,10 +26,8 @@
             FilePath filePath,
             IEnumerable<IPullRequestDiscussionComment> comments)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             comments.NotNull();
 
-            // File path needs to be relative to the repository root.
             if (filePath != null)
             {
                 if (!filePath.IsRelative)
@@ -42,8 +40,6 @@
 
             this.Id = id;
             this.Status = status;
-
-            // ReSharper disable once PossibleMultipleEnumeration
             this.comments.AddRange(comments);
         }
 

--- a/src/Cake.Issues.PullRequests/PullRequestIssueResult.cs
+++ b/src/Cake.Issues.PullRequests/PullRequestIssueResult.cs
@@ -19,16 +19,10 @@
             IEnumerable<IIssue> reportedIssues,
             IEnumerable<IIssue> postedIssues)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             reportedIssues.NotNull();
-
-            // ReSharper disable once PossibleMultipleEnumeration
             postedIssues.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.reportedIssues.AddRange(reportedIssues);
-
-            // ReSharper disable once PossibleMultipleEnumeration
             this.postedIssues.AddRange(postedIssues);
         }
 

--- a/src/Cake.Issues.Reporting.Console/IssueDiagnostic.cs
+++ b/src/Cake.Issues.Reporting.Console/IssueDiagnostic.cs
@@ -28,10 +28,8 @@
         /// <param name="issues">Issues which the diagnostic should describe.</param>
         public IssueDiagnostic(IEnumerable<IIssue> issues)
 
-            // ReSharper disable once PossibleMultipleEnumeration
             : base(issues.First().RuleId)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             this.issues = issues;
 
             var firstIssue = this.issues.First();

--- a/src/Cake.Issues.Reporting.Generic.Tests/ColumnSortOrderExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ColumnSortOrderExtensionsTests.cs
@@ -2,8 +2,6 @@
 {
     using System.Diagnostics.CodeAnalysis;
 
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class ColumnSortOrderExtensionsTests
     {
         public sealed class TheToShortStringMethod

--- a/src/Cake.Issues.Reporting.Generic.Tests/DevExtremeThemeExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/DevExtremeThemeExtensionsTests.cs
@@ -2,8 +2,6 @@
 {
     using System.Diagnostics.CodeAnalysis;
 
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class DevExtremeThemeExtensionsTests
     {
         public sealed class TheGetCssFileNameMethod

--- a/src/Cake.Issues.Reporting.Generic.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ExceptionAssertExtensions.cs
@@ -13,7 +13,6 @@
         /// </summary>
         /// <param name="exception">Exception to check.</param>
         /// <param name="message">Expected exception message.</param>
-        [SuppressMessage("ReSharper", "ParameterOnlyUsedForPreconditionCheck.Global", Justification = "By design for assertions")]
         public static void IsRuntimeBinderException(this Exception exception, string message)
         {
             Assert.IsType<RuntimeBinderException>(exception);

--- a/src/Cake.Issues.Reporting.Generic.Tests/ExpandoObjectExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ExpandoObjectExtensionsTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
     using System.Dynamic;
 
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class ExpandoObjectExtensionsTests
     {
         public sealed class TheSerializeToJsonStringExtensionForAnObject

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFixture.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFixture.cs
@@ -19,12 +19,8 @@
                 GenericIssueReportFormatSettings.FromContent(templateContent);
         }
 
-        // ReSharper disable once MemberCanBePrivate.Global
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public FakeLog Log { get; set; }
 
-        // ReSharper disable once MemberCanBePrivate.Global
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public GenericIssueReportFormatSettings GenericIssueReportFormatSettings { get; set; }
 
         public string CreateReport(IEnumerable<IIssue> issues)

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class GenericIssueReportFormatSettingsExtensionsTests
     {
         public sealed class TheWithOptionWithStringKeyMethod

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportFormatSettingsTests.cs
@@ -1,12 +1,9 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Text;
     using Cake.Core.IO;
 
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class GenericIssueReportFormatSettingsTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportGeneratorTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class GenericIssueReportGeneratorTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportTemplateExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/GenericIssueReportTemplateExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class GenericIssueReportTemplateExtensionsTests
     {
         public sealed class TheGetTemplateResourceNameMethod

--- a/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridColumnDescriptionTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridColumnDescriptionTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class HtmlDxDataGridColumnDescriptionTests
     {
         public sealed class TheCtor

--- a/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridTemplateTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridTemplateTests.cs
@@ -1,10 +1,7 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
     using HtmlAgilityPack;
 
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class HtmlDxDataGridTemplateTests
     {
         public sealed class TheTitleOption

--- a/src/Cake.Issues.Reporting.Generic.Tests/IIssueExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/IIssueExtensionsTests.cs
@@ -1,10 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
-    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Follows name of the class which is tested")]
     public sealed class IIssueExtensionsTests
     {
         public sealed class TheGetExpandoObjectExtension

--- a/src/Cake.Issues.Reporting.Generic.Tests/IdeIntegrationSettingsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/IdeIntegrationSettingsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class IdeIntegrationSettingsTests
     {
         public sealed class TheGetOpenInIdeCallMethod

--- a/src/Cake.Issues.Reporting.Generic.Tests/StringExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/StringExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class StringExtensionsTests
     {
         public sealed class TheSanitizeHtmlIdAttributeExtension

--- a/src/Cake.Issues.Reporting.Generic.Tests/UriExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/UriExtensionsTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class UriExtensionsTests
     {
         public sealed class TheAppendMethod

--- a/src/Cake.Issues.Reporting.Generic.Tests/ViewBagHelperTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/ViewBagHelperTests.cs
@@ -1,9 +1,5 @@
 ﻿namespace Cake.Issues.Reporting.Generic.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-
-    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by test runner")]
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull", Justification = "By design for null tests")]
     public sealed class ViewBagHelperTests
     {
         public sealed class TheValueOrDefaultMethod

--- a/src/Cake.Issues.Reporting.Generic/ExpandoObjectExtensions.cs
+++ b/src/Cake.Issues.Reporting.Generic/ExpandoObjectExtensions.cs
@@ -31,7 +31,6 @@
         /// <returns>Serialized objects.</returns>
         public static string SerializeToJsonString(this IEnumerable<ExpandoObject> expandoObjects)
         {
-            // ReSharper disable PossibleMultipleEnumeration
             expandoObjects.NotNull();
 
             return
@@ -40,8 +39,6 @@
                         expandoObjects
                             .Select(x => new Dictionary<string, object>(x))
                             .ToArray());
-
-            // ReSharper restore PossibleMultipleEnumeration
         }
     }
 }

--- a/src/Cake.Issues.Reporting.Generic/GenericIssueReportFormatAliases.cs
+++ b/src/Cake.Issues.Reporting.Generic/GenericIssueReportFormatAliases.cs
@@ -13,9 +13,6 @@
     /// Cake.Frosting.Issues.Reporting.Generic to use these aliases with Cake Frosting.
     /// </summary>
     [CakeAliasCategory(IssuesAliasConstants.MainCakeAliasCategory)]
-    [SuppressMessage("ReSharper", "UnusedMember.Global", Justification = "Aliases are not used in addin code")]
-    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Aliases are called by Cake scripts")]
-    [SuppressMessage("ReSharper", "UnusedType.Global", Justification = "Class will be loaded by Cake")]
     public static class GenericIssueReportFormatAliases
     {
         /// <summary>

--- a/src/Cake.Issues.Reporting.Generic/HtmlDxDataGridColumnDescription.cs
+++ b/src/Cake.Issues.Reporting.Generic/HtmlDxDataGridColumnDescription.cs
@@ -34,7 +34,6 @@
         /// <summary>
         /// Gets or sets the caption of the column.
         /// </summary>
-        // ReSharper disable once PropertyCanBeMadeInitOnly.Global
         public string Caption { get; set; }
 
         /// <summary>
@@ -42,7 +41,6 @@
         /// See <see cref="ReportColumn"/> for values of default columns.
         /// Default value is zero, which means that the column will be added before any default columns.
         /// </summary>
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public int VisibleIndex { get; set; }
 
         /// <summary>
@@ -50,7 +48,6 @@
         /// Applies only if <see cref="HtmlDxDataGridOption.EnableFiltering"/> is set.
         /// Default value is <c>true</c>.
         /// </summary>
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public bool AllowFiltering { get; set; } = true;
 
         /// <summary>
@@ -58,14 +55,12 @@
         /// Applies only if <see cref="HtmlDxDataGridOption.EnableGrouping"/> is set.
         /// Default value is <c>true</c>.
         /// </summary>
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public bool AllowGrouping { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether a user can sort rows by this column at runtime or not.
         /// Default value is <c>true</c>.
         /// </summary>
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public bool AllowSorting { get; set; } = true;
     }
 }

--- a/src/Cake.Issues.Reporting.Generic/IIssueExtensions.cs
+++ b/src/Cake.Issues.Reporting.Generic/IIssueExtensions.cs
@@ -9,7 +9,6 @@
     /// <summary>
     /// Extension for <see cref="IIssue"/>.
     /// </summary>
-    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Follows name of the interface which is extended")]
     public static class IIssueExtensions
     {
         /// <summary>

--- a/src/Cake.Issues.Reporting.Generic/IdeIntegrationSettings.cs
+++ b/src/Cake.Issues.Reporting.Generic/IdeIntegrationSettings.cs
@@ -8,13 +8,11 @@
         /// <summary>
         /// Gets or sets additional JavaScript which should be added.
         /// </summary>
-        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public string JavaScript { get; set; }
 
         /// <summary>
         /// Gets or sets JavaScript which should be called to open the file affected by an issue in an IDE.
         /// </summary>
-        // ReSharper disable once PropertyCanBeMadeInitOnly.Global
         public string OpenInIdeCall { get; set; }
 
         /// <summary>
@@ -22,7 +20,6 @@
         /// by an issue in an IDE.
         /// Default value is <c>Open in IDE</c>.
         /// </summary>
-        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Global
         public string MenuEntryText { get; set; } = "Open in IDE";
 
         /// <summary>

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportFormatSettings.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportFormatSettings.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.Reporting.Sarif
+﻿namespace Cake.Issues.Reporting.Sarif
 {
     /// <summary>
     /// Settings for <see cref="SarifIssueReportFormatAliases"/>.

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -54,12 +54,10 @@
 
             var log = new SarifLog();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             if (issues.Any())
             {
                 log.Runs = new List<Run>();
 
-                // ReSharper disable once PossibleMultipleEnumeration
                 foreach (var issueGroup in from issue in issues group issue by new { issue.ProviderType, issue.Run })
                 {
                     this.rules = [];

--- a/src/Cake.Issues.Reporting/Aliases.cs
+++ b/src/Cake.Issues.Reporting/Aliases.cs
@@ -146,14 +146,12 @@
         {
             context.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
             reportFormat.NotNull();
             repositoryRoot.NotNull();
             outputFilePath.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return
                 context.CreateIssueReport(
                     issueProviders,
@@ -204,12 +202,10 @@
             context.NotNull();
             reportFormat.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
             var issueReportCreator = new IssueReportCreator(context.Log);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return issueReportCreator.CreateReport(issueProviders, reportFormat, settings);
         }
 
@@ -245,14 +241,12 @@
         {
             context.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNullOrEmptyElement();
 
             reportFormat.NotNull();
             repositoryRoot.NotNull();
             outputFilePath.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return
                 context.CreateIssueReport(
                     issues,
@@ -292,7 +286,6 @@
         {
             context.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNullOrEmptyElement();
 
             reportFormat.NotNull();
@@ -300,7 +293,6 @@
 
             var issueReportCreator = new IssueReportCreator(context.Log);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return issueReportCreator.CreateReport(issues, reportFormat, settings);
         }
     }

--- a/src/Cake.Issues.Reporting/ICreateIssueReportFromIssueProviderSettings.cs
+++ b/src/Cake.Issues.Reporting/ICreateIssueReportFromIssueProviderSettings.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.Reporting
+﻿namespace Cake.Issues.Reporting
 {
     /// <summary>
     /// Setting affecting how reports are created which are built passing issue providers.

--- a/src/Cake.Issues.Reporting/IssueReportFormat.cs
+++ b/src/Cake.Issues.Reporting/IssueReportFormat.cs
@@ -14,7 +14,6 @@
         /// <inheritdoc />
         public FilePath CreateReport(IEnumerable<IIssue> issues)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNullOrEmptyElement();
 
             this.AssertInitialized();

--- a/src/Cake.Issues.Terraform/ValidateOutputDataContract.cs
+++ b/src/Cake.Issues.Terraform/ValidateOutputDataContract.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable InconsistentNaming
-namespace Cake.Issues.Terraform
+﻿namespace Cake.Issues.Terraform
 {
     using System.Runtime.Serialization;
 

--- a/src/Cake.Issues.Testing/AssertionMethodAttribute.cs
+++ b/src/Cake.Issues.Testing/AssertionMethodAttribute.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.Testing
+﻿namespace Cake.Issues.Testing
 {
     using System;
 

--- a/src/Cake.Issues.Testing/FakeConfigurableIssueProvider.cs
+++ b/src/Cake.Issues.Testing/FakeConfigurableIssueProvider.cs
@@ -33,10 +33,8 @@
             IEnumerable<IIssue> issues)
             : base(log, settings)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.issues.AddRange(issues);
         }
 

--- a/src/Cake.Issues.Testing/FakeIssueProvider.cs
+++ b/src/Cake.Issues.Testing/FakeIssueProvider.cs
@@ -27,10 +27,8 @@
         public FakeIssueProvider(ICakeLog log, IEnumerable<IIssue> issues)
             : base(log)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.issues.AddRange(issues);
         }
 

--- a/src/Cake.Issues.Testing/FakeLogFileFormat.cs
+++ b/src/Cake.Issues.Testing/FakeLogFileFormat.cs
@@ -27,10 +27,8 @@
         public FakeLogFileFormat(ICakeLog log, IEnumerable<IIssue> issues)
             : base(log)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.issues.AddRange(issues);
         }
 

--- a/src/Cake.Issues.Testing/FakeRuleDescription.cs
+++ b/src/Cake.Issues.Testing/FakeRuleDescription.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues.Testing
+﻿namespace Cake.Issues.Testing
 {
     /// <summary>
     /// Implementation of a <see cref="BaseRuleDescription"/> for use in test cases.

--- a/src/Cake.Issues.Tests/BaseRuleUrlResolverTests.cs
+++ b/src/Cake.Issues.Tests/BaseRuleUrlResolverTests.cs
@@ -5,7 +5,6 @@
         public sealed class TheClass
         {
             // Ensures that it is possible to define a custom URL resolver for BaseRuleDescription
-            // ReSharper disable once UnusedType.Local
             private class FakeRuleUrlResolverForBaseRuleDescription : BaseRuleUrlResolver<BaseRuleDescription>
             {
                 /// <inheritdoc/>

--- a/src/Cake.Issues.Tests/Testing/FakeIssueProviderFixture.cs
+++ b/src/Cake.Issues.Tests/Testing/FakeIssueProviderFixture.cs
@@ -10,10 +10,8 @@
 
         public FakeIssueProviderFixture(IEnumerable<IIssue> issues)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.issues.AddRange(issues);
         }
 

--- a/src/Cake.Issues/Aliases.ReadIssues.cs
+++ b/src/Cake.Issues/Aliases.ReadIssues.cs
@@ -81,10 +81,8 @@
             context.NotNull();
             repositoryRoot.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             return
                 context.ReadIssues(
                     issueProviders,
@@ -175,10 +173,8 @@
             context.NotNull();
             settings.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             var issuesReader =
                 new IssuesReader(context.Log, issueProviders, settings);
 

--- a/src/Cake.Issues/Aliases.cs
+++ b/src/Cake.Issues/Aliases.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues
+﻿namespace Cake.Issues
 {
     using Cake.Core.Annotations;
 

--- a/src/Cake.Issues/Cake.Issues.csproj
+++ b/src/Cake.Issues/Cake.Issues.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Addin for reading code analyzer or linter issues for the Cake build automation system</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="4.0.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Cake.Issues/IssuesArgumentChecks.cs
+++ b/src/Cake.Issues/IssuesArgumentChecks.cs
@@ -5,7 +5,6 @@
     using System.Diagnostics;
     using System.Linq;
     using System.Runtime.CompilerServices;
-    using JetBrains.Annotations;
 
     /// <summary>
     /// Common runtime checks that throw <see cref="ArgumentException"/> upon failure.
@@ -21,7 +20,7 @@
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
         [DebuggerStepThrough]
         public static void NotNull<T>(
-            [ValidatedNotNull][NoEnumeration] this T value,
+            [ValidatedNotNull] this T value,
             [CallerArgumentExpression(nameof(value))] string parameterName = null)
             where T : class
         {
@@ -95,13 +94,11 @@
         /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is empty.</exception>
         [DebuggerStepThrough]
         public static void NotNullOrEmpty<T>(
-            [NoEnumeration] this IEnumerable<T> value,
+            this IEnumerable<T> value,
             [CallerArgumentExpression(nameof(value))] string parameterName = null)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             value.NotNull(parameterName);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             if (!value.Any())
             {
                 throw new ArgumentException("Empty list.", parameterName);
@@ -119,13 +116,11 @@
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> contains an empty element.</exception>
         [DebuggerStepThrough]
         public static void NotNullOrEmptyElement<T>(
-            [NoEnumeration] this IEnumerable<T> value,
+            this IEnumerable<T> value,
             [CallerArgumentExpression(nameof(value))] string parameterName = null)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             value.NotNull(parameterName);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             if (value.Any(x => x == null))
             {
                 throw new ArgumentOutOfRangeException(parameterName, "List contains.");
@@ -143,13 +138,11 @@
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="value"/> contains an empty element.</exception>
         [DebuggerStepThrough]
         public static void NotNullOrEmptyOrEmptyElement<T>(
-            [NoEnumeration] this IEnumerable<T> value,
+            this IEnumerable<T> value,
             [CallerArgumentExpression(nameof(value))] string parameterName = null)
         {
-            // ReSharper disable once PossibleMultipleEnumeration
             value.NotNullOrEmpty(parameterName);
 
-            // ReSharper disable once PossibleMultipleEnumeration
             value.NotNullOrEmptyElement(parameterName);
         }
     }

--- a/src/Cake.Issues/IssuesReader.cs
+++ b/src/Cake.Issues/IssuesReader.cs
@@ -27,13 +27,11 @@
             log.NotNull();
             settings.NotNull();
 
-            // ReSharper disable once PossibleMultipleEnumeration
             issueProviders.NotNullOrEmptyOrEmptyElement();
 
             this.log = log;
             this.settings = settings;
 
-            // ReSharper disable once PossibleMultipleEnumeration
             this.issueProviders.AddRange(issueProviders);
         }
 

--- a/src/Cake.Issues/StringPathExtensions.cs
+++ b/src/Cake.Issues/StringPathExtensions.cs
@@ -34,7 +34,6 @@
                 throw new ArgumentException($"Invalid path '{path}'", nameof(path));
             }
 
-            // ReSharper disable once PossibleNullReferenceException
             return
                 Path.IsPathRooted(path) &&
                 !Path.GetPathRoot(path).Equals(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal);

--- a/src/Cake.Issues/ValidatedNotNullAttribute.cs
+++ b/src/Cake.Issues/ValidatedNotNullAttribute.cs
@@ -1,5 +1,4 @@
-﻿// ReSharper disable RedundantTypeDeclarationBody
-namespace Cake.Issues
+﻿namespace Cake.Issues
 {
     using System;
 


### PR DESCRIPTION
No longer run InspectCode in build and cleanup code from ReSharper specific annotations.

In the future we can focus solely on Roslyn analyzers / editorconfig and enforce a strict policy, so that the repo can be worked on with an out of the box IDE without requiring additional tools.