### PR TITLE
(GH-606) Add note that format for InspectCode has changed to SARIF

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.InspectCode.md
+++ b/nuspec/nuget/Cake.Frosting.Issues.InspectCode.md
@@ -4,6 +4,12 @@
 > This is the version of the addin compatible with [Cake Frosting].
 > For addin compatible with [Cake .NET Tool] see [Cake.Issues.InspectCode](https://www.nuget.org/packages/Cake.Issues.InspectCode).
 
+<!--Separator-->
+
+> **NOTE**:
+> Starting with version `2024.1` the default output format of Inspect Code is SARIF which can be parsed using the
+> [Cake.Frosting.Issues.Sarif addin](https://www.nuget.org/packages/Cake.Frosting.Issues.Sarif).
+
 The JetBrains Inspect Code support for the Cake.Issues addin for Cake allows you to read issues logged by JetBrains Inspect Code.
 
 Cake.Issues redefines issue management within the Cake build system by offering a comprehensive, universal, and extensible solution.

--- a/nuspec/nuget/Cake.Issues.InspectCode.md
+++ b/nuspec/nuget/Cake.Issues.InspectCode.md
@@ -4,6 +4,12 @@
 > This is the version of the addin compatible with [Cake .NET Tool].
 > For addin compatible with [Cake Frosting] see [Cake.Frosting.Issues.InspectCode](https://www.nuget.org/packages/Cake.Frosting.Issues.InspectCode).
 
+<!--Separator-->
+
+> **NOTE**:
+> Starting with version `2024.1` the default output format of Inspect Code is SARIF which can be parsed using the
+> [Cake.Issues.Sarif addin](https://www.nuget.org/packages/Cake.Issues.Sarif).
+
 The JetBrains Inspect Code support for the Cake.Issues addin for Cake allows you to read issues logged by JetBrains Inspect Code.
 
 Cake.Issues redefines issue management within the Cake build system by offering a comprehensive, universal, and extensible solution.


### PR DESCRIPTION
Adds a note that default format for InspectCode has changed to SARIF and Cake.Issues.Sarif addin can be used to parse it.

Fixes #606 