### PR TITLE
Make implicit usings transitive available

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.DocFx.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.DocFx.nuspec
@@ -48,6 +48,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.DocFx.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.DocFx.targets" target="build" />
+    <file src="Cake.Frosting.Issues.DocFx.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.DocFx.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.DocFx\bin\Release\net6.0\Cake.Issues.DocFx.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.DocFx\bin\Release\net6.0\Cake.Issues.DocFx.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.EsLint.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.EsLint.nuspec
@@ -48,6 +48,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.EsLint.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.EsLint.targets" target="build" />
+    <file src="Cake.Frosting.Issues.EsLint.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.EsLint.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.EsLint\bin\Release\net6.0\Cake.Issues.EsLint.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.EsLint\bin\Release\net6.0\Cake.Issues.EsLint.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.GitRepository.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.GitRepository.nuspec
@@ -48,6 +48,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.GitRepository.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.GitRepository.targets" target="build" />
+    <file src="Cake.Frosting.Issues.GitRepository.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.GitRepository.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.GitRepository\bin\Release\net6.0\Cake.Issues.GitRepository.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.GitRepository\bin\Release\net6.0\Cake.Issues.GitRepository.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.InspectCode.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.InspectCode.nuspec
@@ -48,6 +48,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.InspectCode.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.InspectCode.targets" target="build" />
+    <file src="Cake.Frosting.Issues.InspectCode.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.InspectCode.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.InspectCode\bin\Release\net6.0\Cake.Issues.InspectCode.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.InspectCode\bin\Release\net6.0\Cake.Issues.InspectCode.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Markdownlint.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Markdownlint.nuspec
@@ -48,6 +48,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.Markdownlint.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Markdownlint.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Markdownlint.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Markdownlint.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Markdownlint\bin\Release\net6.0\Cake.Issues.Markdownlint.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Markdownlint\bin\Release\net6.0\Cake.Issues.Markdownlint.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.MsBuild.nuspec
@@ -52,6 +52,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.MsBuild.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.MsBuild.targets" target="build" />
+    <file src="Cake.Frosting.Issues.MsBuild.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.MsBuild.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net6.0\Cake.Issues.MsBuild.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.MsBuild\bin\Release\net6.0\Cake.Issues.MsBuild.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AppVeyor.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AppVeyor.nuspec
@@ -49,6 +49,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.AppVe
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.PullRequests.AppVeyor.targets" target="build" />
+    <file src="Cake.Frosting.Issues.PullRequests.AppVeyor.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.PullRequests.AppVeyor.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.PullRequests.AppVeyor\bin\Release\net6.0\Cake.Issues.PullRequests.AppVeyor.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.PullRequests.AppVeyor\bin\Release\net6.0\Cake.Issues.PullRequests.AppVeyor.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AzureDevOps.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AzureDevOps.nuspec
@@ -53,6 +53,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.Azure
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.PullRequests.AzureDevOps.targets" target="build" />
+    <file src="Cake.Frosting.Issues.PullRequests.AzureDevOps.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.PullRequests.AzureDevOps.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.PullRequests.AzureDevOps\bin\Release\net6.0\Cake.Issues.PullRequests.AzureDevOps.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.PullRequests.AzureDevOps\bin\Release\net6.0\Cake.Issues.PullRequests.AzureDevOps.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.GitHubActions.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.GitHubActions.nuspec
@@ -49,6 +49,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.GitHu
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.PullRequests.GitHubActions.targets" target="build" />
+    <file src="Cake.Frosting.Issues.PullRequests.GitHubActions.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.PullRequests.GitHubActions.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.PullRequests.GitHubActions\bin\Release\net6.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.PullRequests.GitHubActions\bin\Release\net6.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.nuspec
@@ -49,6 +49,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.
   <files>
     <file src="icon.png" target="" />
 	  <file src="Cake.Frosting.Issues.PullRequests.targets" target="build" />
+	  <file src="Cake.Frosting.Issues.PullRequests.targets" target="buildTransitive" />
 	  <file src="Cake.Frosting.Issues.PullRequests.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net6.0\Cake.Issues.PullRequests.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.PullRequests\bin\Release\net6.0\Cake.Issues.PullRequests.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Console.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Console.nuspec
@@ -54,6 +54,7 @@ The addin requires Cake Frosting 1.2.0 or higher.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Reporting.Console.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Reporting.Console.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Reporting.Console.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net6.0\Cake.Issues.Reporting.Console.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Reporting.Console\bin\Release\net6.0\Cake.Issues.Reporting.Console.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
@@ -52,6 +52,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Reporting.Generic.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Reporting.Generic.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Reporting.Generic.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Reporting.Generic\bin\Release\net6.0\Cake.Issues.Reporting.Generic.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Sarif.nuspec
@@ -52,6 +52,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Sarif.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Reporting.Sarif.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Reporting.Sarif.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Reporting.Sarif.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Reporting.Sarif\bin\Release\net6.0/Cake.Issues.Reporting.Sarif.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Reporting.Sarif\bin\Release\net6.0/Cake.Issues.Reporting.Sarif.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.nuspec
@@ -46,6 +46,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Reporting.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Reporting.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Reporting.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Reporting\bin\Release\net6.0\Cake.Issues.Reporting.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Reporting\bin\Release\net6.0\Cake.Issues.Reporting.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Sarif.nuspec
@@ -51,6 +51,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.Sarif.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Sarif.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Sarif.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Sarif.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Sarif\bin\Release\net6.0\Cake.Issues.Sarif.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Sarif\bin\Release\net6.0\Cake.Issues.Sarif.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Frosting.Issues.Terraform.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Terraform.nuspec
@@ -48,6 +48,7 @@ For addin compatible with Cake Script Runners see Cake.Issues.Terraform.
   <files>
     <file src="icon.png" target="" />
     <file src="Cake.Frosting.Issues.Terraform.targets" target="build" />
+    <file src="Cake.Frosting.Issues.Terraform.targets" target="buildTransitive" />
     <file src="Cake.Frosting.Issues.Terraform.md" target="docs\README.md" />
     <file src="..\..\src\Cake.Issues.Terraform\bin\Release\net6.0\Cake.Issues.Terraform.dll" target="lib\net6.0" />
     <file src="..\..\src\Cake.Issues.Terraform\bin\Release\net6.0\Cake.Issues.Terraform.pdb" target="lib\net6.0" />

--- a/nuspec/nuget/Cake.Issues.nuspec
+++ b/nuspec/nuget/Cake.Issues.nuspec
@@ -29,6 +29,7 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\Cake.Issues.targets" target="build" />
+    <file src="..\..\..\..\nuspec\nuget\Cake.Issues.targets" target="buildTransitive" />
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
     <file src="..\..\..\..\nuspec\nuget\Cake.Issues.md" target="docs\README.md" />
     <file src="Release\**\Cake.Issues.*" target="lib" exclude="**\*.deps.json" />


### PR DESCRIPTION
Makes implicit usings flow transitively to any consuming project. This makes them for example also available for users of Cake.Issues.Recipe.