### PR TITLE
Fix wrong conversion for Kind in SARIF report

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif/IIssueExtensions.cs
+++ b/src/Cake.Issues.Reporting.Sarif/IIssueExtensions.cs
@@ -20,8 +20,10 @@ internal static class IIssueExtensions
         return issue.Priority.HasValue
             ? issue.Priority switch
             {
-                (int)IssuePriority.Suggestion or (int)IssuePriority.Hint => ResultKind.Informational,
-                (int)IssuePriority.Warning or (int)IssuePriority.Error => ResultKind.Fail,
+                (int)IssuePriority.Suggestion or
+                (int)IssuePriority.Hint or
+                (int)IssuePriority.Warning or
+                (int)IssuePriority.Error => ResultKind.Fail,
                 _ => ResultKind.NotApplicable,
             }
             : ResultKind.None;


### PR DESCRIPTION
Fixes wrong conversion for `Kind` in the SARIF report. 

Based on [SARIF specification §3.27.9](https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127838) `kind` should be `fail` if `level` contains a value other than `none`:

> If level has any value other than "none" and kind is present, then kind SHALL have the value "fail".

In the report it was already always reported as `fail` because setting `level`, which we do after setting `kind` makes sure that `kind` is set to `fail` and overwrites the wrong conversion done before.

This change therefore is solely for cleaning up code and won't have any impact on generated report which already are correct.