### PR TITLE
Add support for correlationGuid in SARIF reports

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
@@ -319,6 +319,56 @@ public sealed class SarifIssueReportGeneratorTests
             run2.AutomationDetails.Id.ShouldBe(runDescription2);
         }
 
+
+        [Fact]
+        public void Should_Set_CorrelationGuid_If_Defined()
+        {
+            // Given
+            var correlationGuid = Guid.NewGuid();
+            var fixture = new SarifIssueReportFixture();
+            fixture.SarifIssueReportFormatSettings.CorrelationGuid = correlationGuid;
+            var issues =
+                 new List<IIssue>
+                 {
+                        IssueBuilder
+                            .NewIssue("Message Foo.", "ProviderType Foo", "ProviderName Foo")
+                            .Create(),
+                 };
+
+            // When
+            var logContents = fixture.CreateReport(issues);
+
+            // Then
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);
+
+            var run = sarifLog.Runs.ShouldHaveSingleItem();
+            run.AutomationDetails.CorrelationGuid.ShouldBe(correlationGuid);
+        }
+
+        [Fact]
+        public void Should_Not_Set_CorrelationGuid_If_Not_Defined()
+        {
+            // Given
+            var fixture = new SarifIssueReportFixture();
+            var issues =
+                 new List<IIssue>
+                 {
+                        IssueBuilder
+                            .NewIssue("Message Foo.", "ProviderType Foo", "ProviderName Foo")
+                            .ForRun("Run Foo")
+                            .Create(),
+                 };
+
+            // When
+            var logContents = fixture.CreateReport(issues);
+
+            // Then
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);
+
+            var run = sarifLog.Runs.ShouldHaveSingleItem();
+            run.AutomationDetails.CorrelationGuid.ShouldBeNull();
+        }
+
         [Fact]
         public void Should_Set_OriginalUriBaseIds()
         {

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportFormatSettings.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportFormatSettings.cs
@@ -1,8 +1,22 @@
 ﻿namespace Cake.Issues.Reporting.Sarif;
 
+using System;
+
 /// <summary>
 /// Settings for <see cref="SarifIssueReportFormatAliases"/>.
 /// </summary>
 public class SarifIssueReportFormatSettings
 {
+    /// <summary>
+    /// Gets or sets a Guid shared by all runs of the same type.
+    /// Will be written to the <c>automationDetails.correlationGuid</c> property.
+    /// </summary>
+    /// <remarks>
+    /// Consider an engineering system that allows engineers to define “build definitions”, and that assigns a GUID
+    /// to each build definition.
+    /// In such a system, the build definition’s GUID could serve as <see cref="CorrelationGuid"/>.
+    /// It would be the same for all runs produced by the same build definition, and different between any two runs
+    /// produced by different build definitions.
+    /// </remarks>
+    public Guid CorrelationGuid { get; set; }
 }

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -87,13 +87,20 @@ internal class SarifIssueReportGenerator : IssueReportFormat
                     },
                 };
 
-                if (!string.IsNullOrEmpty(issueGroup.Key.Run))
+                if (!string.IsNullOrEmpty(issueGroup.Key.Run) ||
+                    (this.sarifIssueReportFormatSettings.CorrelationGuid != Guid.Empty))
                 {
-                    run.AutomationDetails =
-                        new RunAutomationDetails
-                        {
-                            Id = issueGroup.Key.Run,
-                        };
+                    run.AutomationDetails = new RunAutomationDetails();
+
+                    if (!string.IsNullOrEmpty(issueGroup.Key.Run))
+                    {
+                        run.AutomationDetails.Id = issueGroup.Key.Run;
+                    }
+
+                    if (this.sarifIssueReportFormatSettings.CorrelationGuid != Guid.Empty)
+                    {
+                        run.AutomationDetails.CorrelationGuid = this.sarifIssueReportFormatSettings.CorrelationGuid;
+                    }
                 }
 
                 if (this.rules.Count != 0)


### PR DESCRIPTION
Add support for `correlationGuid` in SARIF reports as specified in [§3.17.5](https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127719)