### PR TITLE
Update from macOS 11 to macOS 12

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -46,7 +46,7 @@ jobs:
         os: [
           windows-2019, windows-2022,
           ubuntu-20.04, ubuntu-22.04,
-          macos-11, macos-14]
+          macos-12, macos-14]
         dotnet: [6.x, 7.x, 8.x]
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,7 +76,7 @@ jobs:
           windows-2019, windows-2022,
           # Disabled until https://github.com/cake-contrib/Cake.Issues/issues/514 is fixed
           # ubuntu-20.04, ubuntu-22.04,
-          macos-11, macos-14]
+          macos-12, macos-14]
         dotnet: [6.x, 7.x, 8.x]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,7 +19,7 @@ jobs:
           windows-2019, windows-2022,
           ubuntu-20.04, ubuntu-22.04,
           # Cake.Recipe currently does not support macOS 14 (M1)
-          macos-11, macos-13]
+          macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Get the sources


### PR DESCRIPTION
Update tests on oldest macOS version from 11 to 12