### PR TITLE
Update from macOS 11 / 13 to macOS 12  / 14 for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -104,8 +104,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -137,8 +137,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -166,8 +166,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -190,8 +190,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -219,8 +219,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -246,8 +246,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -278,8 +278,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -305,8 +305,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -332,8 +332,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:
@@ -359,8 +359,8 @@ stages:
           imageName: 'windows-2019'
         Windows_Server_2022:
           imageName: 'windows-2022'
-        macOS_11:
-          imageName: 'macOS-11'
+        macOS_12:
+          imageName: 'macOS-12'
         macOS_13:
           imageName: 'macOS-13'
         Ubuntu_20_04:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,8 +74,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -106,8 +106,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -139,8 +139,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -168,8 +168,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -192,8 +192,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -221,8 +221,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -248,8 +248,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -280,8 +280,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -307,8 +307,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -334,8 +334,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:
@@ -361,8 +361,8 @@ stages:
           imageName: 'windows-2022'
         macOS_12:
           imageName: 'macOS-12'
-        macOS_13:
-          imageName: 'macOS-13'
+        macOS_14:
+          imageName: 'macOS-14'
         Ubuntu_20_04:
           imageName: 'ubuntu-20.04'
         Ubuntu_22_04:


### PR DESCRIPTION
Update from macOS 11 / 13 to macOS 12  / 14 for Azure Pipelines