### PR TITLE
(GH-676) Ensure trailing slash for OriginalUriBaseIds

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportFixture.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportFixture.cs
@@ -5,7 +5,7 @@ using Cake.Core.Diagnostics;
 
 internal class SarifIssueReportFixture
 {
-    public const string RepositoryRootPath = @"c:\Source\Cake.Issues.Reporting.Sarif";
+    public const string RepositoryRootPath = @"c:\Source\Cake.Issues.Reporting.Sarif\";
 
     public FakeLog Log { get; set; } = new() { Verbosity = Verbosity.Normal };
 

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -131,7 +131,7 @@ internal class SarifIssueReportGenerator : IssueReportFormat
                         [RepoRootUriBaseId] =
                             new()
                             {
-                                Uri = new Uri(this.Settings.RepositoryRoot.FullPath, UriKind.Absolute),
+                                Uri = new Uri(this.Settings.RepositoryRoot.FullPath.WithEnding("\\"), UriKind.Absolute),
                             },
                     },
                 };


### PR DESCRIPTION
Ensure trailing slash for OriginalUriBaseIds as required by the specification

Fixes #676 