### PR TITLE
(GH-681) Set correct ruleIndex

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
@@ -563,6 +563,39 @@ public sealed class SarifIssueReportGeneratorTests
         }
 
         [Fact]
+        public void Should_Set_Correct_RuleIndex()
+        {
+            // Given
+            var fixture = new SarifIssueReportFixture();
+            var firstRuleId = "Rule Foo";
+            var secondRuleId = "Rule Bar";
+            var ruleUrl = new Uri("https://www.example.come/rules/rule.html");
+            var issues =
+                 new List<IIssue>
+                 {
+                        IssueBuilder
+                            .NewIssue("Message Foo.", "ProviderType Foo", "ProviderName Foo")
+                            .OfRule(firstRuleId, ruleUrl)
+                            .Create(),
+                        IssueBuilder
+                            .NewIssue("Message Bar.", "ProviderType Foo", "ProviderName Foo")
+                            .OfRule(secondRuleId, ruleUrl)
+                            .Create(),
+                 };
+
+            // When
+            var logContents = fixture.CreateReport(issues);
+
+            // Then
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);
+
+            var results = sarifLog.Results();
+            results.Count().ShouldBe(2);
+            results.Single(x => x.RuleId == firstRuleId).RuleIndex.ShouldBe(0);
+            results.Single(x => x.RuleId == secondRuleId).RuleIndex.ShouldBe(1);
+        }
+
+        [Fact]
         public void Should_Set_Text_Message()
         {
             // Given

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -205,7 +205,8 @@ internal class SarifIssueReportGenerator : IssueReportFormat
             {
                 if (!this.ruleIndices.TryGetValue(sarifIssue.Issue.RuleId, out var value))
                 {
-                    this.ruleIndices.Add(sarifIssue.Issue.RuleId, this.rules.Count);
+                    value = this.rules.Count;
+                    this.ruleIndices.Add(sarifIssue.Issue.RuleId, value);
                     this.rules.Add(
                         new ReportingDescriptor
                         {


### PR DESCRIPTION
Sets correct ruleIndex if issues containing a rule URL but with different rule IDs are reported by the same issue provider

Fixes #681  