### PR TITLE
Add option to configure if tool name or fix issue provider name is used

### DIFF
--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderFixture.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderFixture.cs
@@ -3,5 +3,15 @@
 internal class SarifIssuesProviderFixture(string fileResourceName)
     : BaseConfigurableIssueProviderFixture<SarifIssuesProvider, SarifIssuesSettings>(fileResourceName)
 {
+    public bool UseToolNameAsIssueProviderName { get; set; } = true;
+
     protected override string FileResourceNamespace => "Cake.Issues.Sarif.Tests.Testfiles.";
+
+    protected override SarifIssuesSettings CreateIssueProviderSettings()
+    {
+        var settings = base.CreateIssueProviderSettings();
+        settings.UseToolNameAsIssueProviderName = this.UseToolNameAsIssueProviderName;
+        return settings;
+    }
+
 }

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
@@ -119,6 +119,32 @@ public sealed class SarifIssuesProviderTests
         }
 
         [Fact]
+        public void Should_Consider_UseToolNameAsIssueProviderName()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("recommended-without-source.sarif")
+            {
+                UseToolNameAsIssueProviderName = false
+            };
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+            var issue = issues.Single();
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "The insecure method \"Crypto.Sha1.Encrypt\" should not be used.",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "SARIF")
+                    .OfRule("B6412")
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
         public void Should_Read_Issue_Correct_For_File_Generated_By_CakeIssuesReportingSarif()
         {
             // Given

--- a/src/Cake.Issues.Sarif/SarifIssuesProvider.cs
+++ b/src/Cake.Issues.Sarif/SarifIssuesProvider.cs
@@ -29,7 +29,8 @@ internal class SarifIssuesProvider(ICakeLog log, SarifIssuesSettings issueProvid
 
         foreach (var run in logContent.Runs)
         {
-            var toolName = run.Tool.Driver.Name;
+            var issueProviderName =
+                this.IssueProviderSettings.UseToolNameAsIssueProviderName ? run.Tool.Driver.Name : this.ProviderName;
 
             foreach (var sarifResult in run.Results)
             {
@@ -43,7 +44,7 @@ internal class SarifIssuesProvider(ICakeLog log, SarifIssuesSettings issueProvid
                         .NewIssue(
                             text,
                             typeof(SarifIssuesProvider).FullName,
-                            toolName)
+                            issueProviderName)
                         .WithPriority(sarifResult.Level.ToPriority())
                         .OfRule(ruleId, ruleUrl);
 

--- a/src/Cake.Issues.Sarif/SarifIssuesSettings.cs
+++ b/src/Cake.Issues.Sarif/SarifIssuesSettings.cs
@@ -24,4 +24,11 @@ public class SarifIssuesSettings : IssueProviderSettings
         : base(logFileContent)
     {
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the tool name reported in the SARIF log or a fixed value should be
+    /// used as issue provider name.
+    /// Default value is <c>true</c>.
+    /// </summary>
+    public bool UseToolNameAsIssueProviderName { get; set; } = true;
 }

--- a/src/Cake.Issues.Testing/BaseConfigurableIssueProviderFixture.cs
+++ b/src/Cake.Issues.Testing/BaseConfigurableIssueProviderFixture.cs
@@ -59,18 +59,18 @@ public abstract class BaseConfigurableIssueProviderFixture<TIssueProvider, TSett
     /// <summary>
     /// Creates a new instance of the issue provider settings.
     /// </summary>
+    /// <returns>Instance of the issue provider.</returns>
+    protected virtual TSettings CreateIssueProviderSettings() =>
+        (TSettings)Activator.CreateInstance(
+            typeof(TSettings),
+            [.. this.GetCreateIssueProviderSettingsArguments()]);
+
+    /// <summary>
+    /// Creates a new instance of the issue provider settings.
+    /// </summary>
     /// <returns>Instance of the issue provider settings.</returns>
     protected virtual IList<object> GetCreateIssueProviderSettingsArguments() =>
         this.LogFileContent != null
             ? [this.LogFileContent]
             : throw new InvalidOperationException("No log content set.");
-
-    /// <summary>
-    /// Creates a new instance of the issue provider settings.
-    /// </summary>
-    /// <returns>Instance of the issue provider.</returns>
-    private TSettings CreateIssueProviderSettings() =>
-        (TSettings)Activator.CreateInstance(
-            typeof(TSettings),
-            [.. this.GetCreateIssueProviderSettingsArguments()]);
 }


### PR DESCRIPTION
Add option which allows to configure if tool name or fix issue provider name is used.

Also makes `BaseConfigurableIssueProviderFixture.CreateIssueProviderSettings` overridable in specific test fixtures.

Fixes #686
Fixes #685