### PR TITLE
Fix repo root directory when not running on Windows

### DIFF
--- a/src/Cake.Issues.Terraform/TerraformIssuesAliases.cs
+++ b/src/Cake.Issues.Terraform/TerraformIssuesAliases.cs
@@ -53,7 +53,7 @@ public static class TerraformIssuesAliases
         context.NotNull();
         validateOutputFilePath.NotNull();
 
-        return context.TerraformIssuesFromFilePath(validateOutputFilePath, "/");
+        return context.TerraformIssuesFromFilePath(validateOutputFilePath, "./");
     }
 
     /// <summary>
@@ -118,7 +118,7 @@ public static class TerraformIssuesAliases
         context.NotNull();
         validateOutput.NotNullOrWhiteSpace();
 
-        return context.TerraformIssues(new TerraformIssuesSettings(validateOutput.ToByteArray(), "/"));
+        return context.TerraformIssues(new TerraformIssuesSettings(validateOutput.ToByteArray(), "./"));
     }
 
     /// <summary>


### PR DESCRIPTION
Fix repository root directory when running on Linux or macOS, where the current folder and not the filesystem root folder should be used.