### PR TITLE
Ensure issues with only different file link have unchanged state

### DIFF
--- a/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Sarif.Tests/SarifIssueReportGeneratorTests.cs
@@ -968,6 +968,46 @@ public sealed class SarifIssueReportGeneratorTests
         }
 
         [Fact]
+        public void Should_Generate_Report_With_BaseLineState_Unchanged_If_Only_File_Link_Has_Changed()
+        {
+            // Given
+            var fixture = new SarifIssueReportFixture();
+            fixture.SarifIssueReportFormatSettings.BaselineGuid = Guid.NewGuid();
+
+            var issues =
+                new List<IIssue>
+                {
+                    IssueBuilder
+                        .NewIssue("Message Foo.", "ProviderType Foo", "ProviderName Foo")
+                        .WithFileLink(new Uri("https://github.com/cake-contrib/Cake.Issues/blob/develop/src/Cake.Issues.MsBuild/BaseMsBuildLogFileFormat.cs"))
+                        .Create(),
+
+                };
+
+            var existingIssues =
+                new List<IIssue>
+                {
+                    IssueBuilder
+                        .NewIssue("Message Foo.", "ProviderType Foo", "ProviderName Foo")
+                        .WithFileLink(new Uri("https://github.com/cake-contrib/Cake.Issues/blob/master/src/Cake.Issues.MsBuild/BaseMsBuildLogFileFormat.cs"))
+                        .Create(),
+
+                };
+
+            fixture.SarifIssueReportFormatSettings.ExistingIssues.AddRange(existingIssues);
+
+            // When
+            var logContents = fixture.CreateReport(issues);
+
+            // Then
+            var sarifLog = JsonConvert.DeserializeObject<SarifLog>(logContents);
+
+            var run = sarifLog.Runs.ShouldHaveSingleItem();
+            var result = run.Results.ShouldHaveSingleItem();
+            result.BaselineState.ShouldBe(BaselineState.Unchanged);
+        }
+
+        [Fact]
         public void Should_Generate_Report_With_BaseLineState_New_If_New_Issue()
         {
             // Given

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -54,7 +54,10 @@ internal class SarifIssueReportGenerator : IssueReportFormat
         if (this.sarifIssueReportFormatSettings.BaselineGuid != Guid.Empty)
         {
             var issueComparerOnlyPersistentProperties = new IIssueComparer(true);
-            var issueComparerAllProperties = new IIssueComparer(false);
+
+            // Always ignore file link, since it might contain commit ID which is different even on identical issues
+            // from different runs.
+            var issueComparerAllProperties = new IIssueComparer(IIssueProperty.FileLink);
 
             var unchangedIssues = new List<IIssue>();
             var updatedIssues = new List<IIssue>();


### PR DESCRIPTION
Updates SARIF report generation that files which only differ by file link, which might contain a commit id or branch name, are marked as unchanged and not updated.

Fixes #692