### PR TITLE
Revert back to Cake.Recipe 3.1.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
 #  Build Script                   #
 #---------------------------------#
 build_script:
-  - ps: .\build.ps1 --target=CI --verbosity=diagnostic
+  - ps: .\build.ps1 --target=CI
 
 # Tests
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ install:
 #  Build Script                   #
 #---------------------------------#
 build_script:
-  - ps: .\build.ps1 --target=CI
+  - ps: .\build.ps1 --target=CI --verbosity=diagnostic
 
 # Tests
 test: off

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.3.0",
+      "version": "1.3.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins/nuget/v3/index.json?package=Cake.Recipe&version=4.0.0-alpha0126
+#load nuget:?package=Cake.Recipe&version=3.1.1
 
 //*************************************************************************************************
 // Settings
@@ -17,9 +17,15 @@ BuildParameters.SetParameters(
     shouldUseDeterministicBuilds: true,
     shouldGenerateDocumentation: false, // Documentation is generated from Cake.Issues.Website
     shouldRunInspectCode: false,
-    shouldRunCoveralls: false);  // Disabled because it's currently failing
+    shouldRunCoveralls: false,  // Disabled because it's currently failing
+    shouldPostToGitter: false); // Disabled because it's currently failing
 
 BuildParameters.PrintParameters(Context);
+
+ToolSettings.SetToolPreprocessorDirectives(
+    gitReleaseManagerGlobalTool: "#tool dotnet:?package=GitReleaseManager.Tool&version=0.17.0",
+    nugetTool: "#tool nuget:?package=NuGet.CommandLine&version=6.9.1"
+);
 
 ToolSettings.SetToolSettings(
     context: Context,
@@ -48,7 +54,7 @@ Setup(context =>
 // Task overrides
 //*************************************************************************************************
 
-// Since Cake.Recipe does not detect the correct settings when using Directory.Build.props we need
+// Since Cake.Recipe does not detect the correct settings when using Directory.Build.pros we need
 // to override the test task
 ((CakeTask)BuildParameters.Tasks.DotNetCoreTestTask.Task).Actions.Clear();
 BuildParameters.Tasks.DotNetCoreTestTask.Does<DotNetCoreMSBuildSettings>((context, msBuildSettings) => {
@@ -96,12 +102,38 @@ BuildParameters.Tasks.DotNetCoreTestTask.Does<DotNetCoreMSBuildSettings>((contex
     }
 });
 
+// Update to latest InspectCode version which generates a SARIF file
+((CakeTask)BuildParameters.Tasks.InspectCodeTask.Task).Actions.Clear();
+BuildParameters.Tasks.InspectCodeTask
+    .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows")
+    .WithCriteria(() => BuildParameters.ShouldRunInspectCode, "Skipping because InspectCode has been disabled")
+    .Does<BuildData>(data => RequireTool(ToolSettings.ReSharperTools, () => {
+        var inspectCodeLogFilePath = BuildParameters.Paths.Directories.InspectCodeTestResults.CombineWithFilePath("inspectcode.xml");
+
+        var settings = new InspectCodeSettings() {
+            SolutionWideAnalysis = true,
+            OutputFile = inspectCodeLogFilePath,
+            ArgumentCustomization = x => x.Append("--no-build").Append("-f=xml")
+        };
+
+        if (FileExists(BuildParameters.SourceDirectoryPath.CombineWithFilePath(BuildParameters.ResharperSettingsFileName)))
+        {
+            settings.Profile = BuildParameters.SourceDirectoryPath.CombineWithFilePath(BuildParameters.ResharperSettingsFileName);
+        }
+
+        InspectCode(BuildParameters.SolutionFilePath, settings);
+
+        // Pass path to InspectCode log file to Cake.Issues.Recipe
+        IssuesParameters.InputFiles.AddInspectCodeLogFile(inspectCodeLogFilePath);
+    })
+);
+
 // Upload only .NET 8 coverage results to avoid issues with files being too large
 ((CakeTask)BuildParameters.Tasks.UploadCodecovReportTask.Task).Actions.Clear();
 BuildParameters.Tasks.UploadCodecovReportTask
     .WithCriteria(() => BuildParameters.IsMainRepository, "Skipping because not running from the main repository")
     .WithCriteria(() => BuildParameters.ShouldRunCodecov, "Skipping because uploading to codecov is disabled")
-    .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on GitHub CI")
+    .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on appveyor")
     .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.CodecovGlobalTool : ToolSettings.CodecovTool, () => {
         var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.net8.0.opencover.xml");
         if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
@@ -113,8 +145,7 @@ BuildParameters.Tasks.UploadCodecovReportTask
         {
             var settings = new CodecovSettings {
                 Files = coverageFiles.Select(f => f.FullPath),
-                NonZero = true,
-                Token = BuildParameters.Codecov.RepoToken
+                Required = true
             };
             if (buildVersion != null &&
                 !string.IsNullOrEmpty(buildVersion.FullSemVersion) &&

--- a/recipe.cake
+++ b/recipe.cake
@@ -112,7 +112,7 @@ BuildParameters.Tasks.UploadCodecovReportTask
         if (coverageFiles.Any())
         {
             var settings = new CodecovSettings {
-                Files = coverageFiles.Select(f => f.FullPath.Replace("/", "\\")),
+                Files = coverageFiles.Select(f => f.FullPath),
                 NonZero = true,
                 Token = BuildParameters.Codecov.RepoToken
             };


### PR DESCRIPTION
Revert back to Cake.Recipe 3.1.1 since code coverage reporting from multiple files currently does not work correctly in Cake.Recipe 4 preview.