### PR TITLE
(GH-716) Don't create file links for issues without a file path

### DIFF
--- a/src/Cake.Issues.Tests/FileLinkSettingsTests.cs
+++ b/src/Cake.Issues.Tests/FileLinkSettingsTests.cs
@@ -122,5 +122,39 @@ public sealed class FileLinkSettingsTests
             // Then
             result.IsArgumentNullException("issue");
         }
+
+        [Fact]
+        public void Should_Return_Null_If_Issue_Has_No_Path_Set()
+        {
+            // Given
+            var issue =
+                IssueBuilder
+                    .NewIssue("Foo", "ProviderTypeFoo", "ProviderNameFoo")
+                    .Create();
+
+            // When
+            var result = FileLinkSettings.ForPattern("foo").GetFileLink(issue);
+
+            // Then
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_Return_Correct_Pattern()
+        {
+            // Given
+            var issue =
+                IssueBuilder
+                    .NewIssue("Foo", "ProviderTypeFoo", "ProviderNameFoo")
+                    .InFile(@"src\ClassLibrary1\ClassLibrary1.csproj")
+                    .Create();
+            var pattern = "https://example.com/";
+
+            // When
+            var result = FileLinkSettings.ForPattern(pattern).GetFileLink(issue);
+
+            // Then
+            result.ToString().ShouldBe(pattern);
+        }
     }
 }

--- a/src/Cake.Issues/FileLinkSettings.cs
+++ b/src/Cake.Issues/FileLinkSettings.cs
@@ -81,11 +81,15 @@ public class FileLinkSettings
     /// for the issue <paramref name="issue"/>.
     /// </summary>
     /// <param name="issue">Issue for which the link should be returned.</param>
-    /// <returns>URL to the file on the source code hosting system.</returns>
+    /// <returns>URL to the file on the source code hosting system or <c>null</c>
+    /// if the issue is not related to a file.</returns>
     public Uri GetFileLink(IIssue issue)
     {
         issue.NotNull();
 
-        return this.builder(issue, new Dictionary<string, string>());
+        return
+            issue.AffectedFileRelativePath == null
+                ? null
+                : this.builder(issue, new Dictionary<string, string>());
     }
 }


### PR DESCRIPTION
Ensures that for issues which are not related to a file no file link is created.

Fixes #716 