### PR TITLE
Optimize build time for integration tests on GitHub

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -29,7 +29,7 @@ jobs:
             7.x
             8.x
       - name: Build
-        run: ./build.sh
+        run: ./build.sh --target=Create-NuGet-Packages
         shell: bash
       - name: Publish NuGet package as build artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4


### PR DESCRIPTION
Optimize build time for integration tests on GitHub by only running tasks required for creating NuGet packages. Unit tests are no longer run, since they run in a separate workflow.