### PR TITLE
Ensure .NET 5 is available on build agents

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,8 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  # .NET 5 required for Codecov.Tool
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.425 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.409 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.402 -InstallDir $env:DOTNET_INSTALL_DIR'

--- a/.azuredevops/pipelines/templates/steps/install-net5.yml
+++ b/.azuredevops/pipelines/templates/steps/install-net5.yml
@@ -1,0 +1,7 @@
+# Installs .NET 6
+
+steps:
+  - task: UseDotNet@2
+    inputs:
+      version: '5.x'
+    displayName: 'Install .NET 5'

--- a/.azuredevops/pipelines/templates/steps/install-required-dotnet-versions-for-building.yml
+++ b/.azuredevops/pipelines/templates/steps/install-required-dotnet-versions-for-building.yml
@@ -1,6 +1,8 @@
 # Installs required .NET SDKs for building the solution.
 
 steps:
+  # .NET 5 required for Codecov.Tool
+  - template: install-net5.yml
   - template: install-net6.yml
   - template: install-net7.yml
   - template: install-net8.yml


### PR DESCRIPTION
Ensure .NET 5, which is required for Codecov.Tool, is available on build agents