### PR TITLE
Update transitive dependencies to fix security vulnerabilities

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Reporting.Generic.nuspec
@@ -32,14 +32,20 @@ For addin compatible with Cake Script Runners see Cake.Issues.Reporting.Generic.
       <group targetFramework="net6.0">
         <dependency id="Cake.Frosting.Issues.Reporting" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
         <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+        <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+        <dependency id="System.Text.Encodings.Web" version="4.7.2" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Cake.Frosting.Issues.Reporting" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
         <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+        <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+        <dependency id="System.Text.Encodings.Web" version="4.7.2" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Cake.Frosting.Issues.Reporting" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
         <dependency id="Gazorator" version="0.5.2" exclude="Build,Analyzers" />
+        <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+        <dependency id="System.Text.Encodings.Web" version="4.7.2" />
       </group>
     </dependencies>
   </metadata>

--- a/nuspec/nuget/Cake.Frosting.Issues.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.Sarif.nuspec
@@ -35,16 +35,22 @@ For addin compatible with Cake Script Runners see Cake.Issues.Sarif.
         <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
         <dependency id="Sarif.Sdk" version="4.5.4" exclude="Build,Analyzers" />
+        <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+        <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
         <dependency id="Sarif.Sdk" version="4.5.4" exclude="Build,Analyzers" />
+        <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+        <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Cake.Core" version="4.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Issues" version="[4.0.0-beta0001,5.0)" exclude="Build,Analyzers" />
         <dependency id="Sarif.Sdk" version="4.5.4" exclude="Build,Analyzers" />
+        <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+        <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
+++ b/src/Cake.Issues.Reporting.Generic.Tests/Cake.Issues.Reporting.Generic.Tests.csproj
@@ -15,6 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.68" />
+    <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
+++ b/src/Cake.Issues.Reporting.Generic/Cake.Issues.Reporting.Generic.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Support for creating issue reports in any text based format (HTML, Markdown, ...) from the Cake.Issues Addin for Cake Build Automation System</Description>
   </PropertyGroup>
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Gazorator" Version="0.5.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
+++ b/src/Cake.Issues.Reporting.Sarif/Cake.Issues.Reporting.Sarif.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Support for creating SARIF compatible files for the Cake.Issues addin for Cake Build Automation System</Description>
   </PropertyGroup>
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Sarif.Sdk" Version="4.5.4" />
+    <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.Issues.Sarif/Cake.Issues.Sarif.csproj
+++ b/src/Cake.Issues.Sarif/Cake.Issues.Sarif.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Sarif.Sdk" Version="4.5.4" />
+    <!--Transitive dependencies specified explicitely to fix security vulnerabilities-->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update transitive dependencies which contain known security vulnerabilities to where vulnerabilities have been fixed:

- Cake.Issues.Reporting.Generic
  - Update System.Text.Encodings.Web to 4.7.2
- Cake.Issues.Sarif
  - Update Newtonsoft.Json to 13.0.1