### PR TITLE
Fix linting issues

### DIFF
--- a/src/Cake.Issues.InspectCode/InspectCodeIssuesProvider.cs
+++ b/src/Cake.Issues.InspectCode/InspectCodeIssuesProvider.cs
@@ -241,7 +241,7 @@ internal class InspectCodeIssuesProvider(ICakeLog log, InspectCodeIssuesSettings
     /// <summary>
     /// Description of an issue type.
     /// </summary>
-    private class IssueType
+    private sealed class IssueType
     {
         /// <summary>
         /// Gets the description of the issue.

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliJsonLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliJsonLogFileFormat.cs
@@ -102,7 +102,7 @@ internal class MarkdownlintCliJsonLogFileFormat(ICakeLog log)
 #pragma warning disable CS0649 // Field 'field' is never assigned to, and will always have its default value 'value'
 
     [DataContract]
-    private class LogFileEntry
+    private sealed class LogFileEntry
     {
         [DataMember]
         public string fileName;

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
@@ -27,7 +27,7 @@ internal partial class MarkdownlintCliLogFileFormat(ICakeLog log)
 
         var regex = LineParsingRegEx();
 
-        foreach (var line in markdownlintIssuesSettings.LogFileContent.ToStringUsingEncoding().Split(Separator, StringSplitOptions.None).ToList().Where(s => !string.IsNullOrEmpty(s)))
+        foreach (var line in markdownlintIssuesSettings.LogFileContent.ToStringUsingEncoding().Split(Separator, StringSplitOptions.None).Where(s => !string.IsNullOrEmpty(s)))
         {
             var groups = regex.Match(line).Groups;
 

--- a/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
+++ b/src/Cake.Issues.Markdownlint/LogFileFormat/MarkdownlintCliLogFileFormat.cs
@@ -10,7 +10,7 @@ using Cake.Core.Diagnostics;
 /// Logfile format as written by markdownlint-cli.
 /// </summary>
 /// <param name="log">The Cake log instance.</param>
-internal class MarkdownlintCliLogFileFormat(ICakeLog log)
+internal partial class MarkdownlintCliLogFileFormat(ICakeLog log)
     : BaseMarkdownlintLogFileFormat(log)
 {
     private static readonly string[] Separator = ["\r\n", "\r", "\n"];
@@ -25,7 +25,7 @@ internal class MarkdownlintCliLogFileFormat(ICakeLog log)
         repositorySettings.NotNull();
         markdownlintIssuesSettings.NotNull();
 
-        var regex = new Regex(@"(?<filePath>.*[^:\d+]): ?(?<lineNumber>\d+):?(?<columnNumber>\d+)? (?<ruleId>MD\d+)/(?<ruleName>(?:\w*-*/*)*) (?<message>.*)");
+        var regex = LineParsingRegEx();
 
         foreach (var line in markdownlintIssuesSettings.LogFileContent.ToStringUsingEncoding().Split(Separator, StringSplitOptions.None).ToList().Where(s => !string.IsNullOrEmpty(s)))
         {
@@ -56,6 +56,9 @@ internal class MarkdownlintCliLogFileFormat(ICakeLog log)
                     .Create();
         }
     }
+
+    [GeneratedRegex(@"(?<filePath>.*[^:\d+]): ?(?<lineNumber>\d+):?(?<columnNumber>\d+)? (?<ruleId>MD\d+)/(?<ruleName>(?:\w*-*/*)*) (?<message>.*)")]
+    private static partial Regex LineParsingRegEx();
 
     /// <summary>
     /// Reads the affected file path from a parsed entry.

--- a/src/Cake.Issues.Markdownlint/MarkdownlintRuleUrlResolver.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintRuleUrlResolver.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 /// <summary>
 /// Class for retrieving a URL linking to a site describing a rule.
 /// </summary>
-internal class MarkdownlintRuleUrlResolver : BaseRuleUrlResolver<MarkdownlintRuleDescription>
+internal partial class MarkdownlintRuleUrlResolver : BaseRuleUrlResolver<MarkdownlintRuleDescription>
 {
     private static readonly Lazy<MarkdownlintRuleUrlResolver> InstanceValue =
         new(() => new MarkdownlintRuleUrlResolver());
@@ -28,7 +28,7 @@ internal class MarkdownlintRuleUrlResolver : BaseRuleUrlResolver<MarkdownlintRul
     /// <inheritdoc/>
     protected override bool TryGetRuleDescription(string rule, MarkdownlintRuleDescription ruleDescription)
     {
-        var regex = new Regex(@"^MD(\d*)$");
+        var regex = RuleDescriptionRegEx();
         var match = regex.Match(rule);
 
         if (!match.Success)
@@ -52,4 +52,7 @@ internal class MarkdownlintRuleUrlResolver : BaseRuleUrlResolver<MarkdownlintRul
 
         return true;
     }
+
+    [GeneratedRegex(@"^MD(\d*)$")]
+    private static partial Regex RuleDescriptionRegEx();
 }

--- a/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportGeneratorTests.cs
+++ b/src/Cake.Issues.Reporting.Console.Tests/ConsoleIssueReportGeneratorTests.cs
@@ -34,12 +34,14 @@ public sealed class ConsoleIssueReportGeneratorTests
     public sealed class TheInternalCreateReportMethod
     {
         public static IEnumerable<object[]> ReportFormatSettingsCombinations =>
-            from b1 in new[] { false, true }
-            from b2 in new[] { false, true }
-            from b3 in new[] { false, true }
-            from b4 in new[] { false, true }
-            from b5 in new[] { false, true }
+            from b1 in boolArray
+            from b2 in boolArray
+            from b3 in boolArray
+            from b4 in boolArray
+            from b5 in boolArray
             select new object[] { b1, b2, b3, b4, b5 };
+
+        private static readonly bool[] boolArray = [false, true];
 
         [Theory]
         [MemberData(nameof(ReportFormatSettingsCombinations))]

--- a/src/Cake.Issues.Reporting.Console/IssueDiagnostic.cs
+++ b/src/Cake.Issues.Reporting.Console/IssueDiagnostic.cs
@@ -54,43 +54,11 @@ internal sealed class IssueDiagnostic : Diagnostic
     }
 
     /// <summary>
-    /// Creates labels for the issue.
-    /// </summary>
-    private void CreateLabels()
-    {
-        var color = this.issues.First().Priority switch
-        {
-            (int)IssuePriority.Error => Color.Red,
-            (int)IssuePriority.Warning => Color.Yellow,
-            (int)IssuePriority.Suggestion or (int)IssuePriority.Hint => Color.Blue,
-            _ => throw new Exception(),
-        };
-
-        foreach (var issue in this.issues)
-        {
-            var (location, length) = this.GetLocation(issue);
-            var label =
-                new Label(
-                    issue.AffectedFileRelativePath.FullPath,
-                    location,
-                    issue.Message(IssueCommentFormat.PlainText))
-                .WithColor(color);
-
-            if (length > 0)
-            {
-                label = label.WithLength(length);
-            }
-
-            this.Labels.Add(label);
-        }
-    }
-
-    /// <summary>
     /// Returns the diagnostic location of an issue.
     /// </summary>
     /// <param name="issue">Issue for which the location should be returned.</param>
     /// <returns>Location for the diagnostic.</returns>
-    private (Location Location, int Lenght) GetLocation(IIssue issue)
+    private static (Location Location, int Lenght) GetLocation(IIssue issue)
     {
         // Errata currently doesn't support file or line level diagnostics.
         if (!issue.Line.HasValue || !issue.Column.HasValue)
@@ -107,5 +75,37 @@ internal sealed class IssueDiagnostic : Diagnostic
         }
 
         return (location, length);
+    }
+
+    /// <summary>
+    /// Creates labels for the issue.
+    /// </summary>
+    private void CreateLabels()
+    {
+        var color = this.issues.First().Priority switch
+        {
+            (int)IssuePriority.Error => Color.Red,
+            (int)IssuePriority.Warning => Color.Yellow,
+            (int)IssuePriority.Suggestion or (int)IssuePriority.Hint => Color.Blue,
+            _ => throw new Exception(),
+        };
+
+        foreach (var issue in this.issues)
+        {
+            var (location, length) = GetLocation(issue);
+            var label =
+                new Label(
+                    issue.AffectedFileRelativePath.FullPath,
+                    location,
+                    issue.Message(IssueCommentFormat.PlainText))
+                .WithColor(color);
+
+            if (length > 0)
+            {
+                label = label.WithLength(length);
+            }
+
+            this.Labels.Add(label);
+        }
     }
 }

--- a/src/Cake.Issues.Reporting.Generic.Tests/DevExtremeThemeExtensionsTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/DevExtremeThemeExtensionsTests.cs
@@ -6,7 +6,7 @@ public sealed class DevExtremeThemeExtensionsTests
     {
         public static IEnumerable<object[]> DevExtremeThemes()
         {
-            foreach (var number in Enum.GetValues(typeof(DevExtremeTheme)))
+            foreach (var number in Enum.GetValues<DevExtremeTheme>())
             {
                 yield return [number];
             }

--- a/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridTemplateTests.cs
+++ b/src/Cake.Issues.Reporting.Generic.Tests/HtmlDxDataGridTemplateTests.cs
@@ -50,7 +50,7 @@ public sealed class HtmlDxDataGridTemplateTests
     public sealed class TheThemeOption
     {
         public static IEnumerable<object[]> DevExtremeThemes() =>
-            from object number in Enum.GetValues(typeof(DevExtremeTheme))
+            from object number in Enum.GetValues<DevExtremeTheme>()
             select new[] { number };
 
         [Theory]

--- a/src/Cake.Issues.Reporting.Generic/StringExtensions.cs
+++ b/src/Cake.Issues.Reporting.Generic/StringExtensions.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 /// <summary>
 /// Extensions for <see cref="string"/>.
 /// </summary>
-public static class StringExtensions
+public static partial class StringExtensions
 {
     /// <summary>
     /// Sanitizes a string to be a valid HTML ID.
@@ -23,7 +23,7 @@ public static class StringExtensions
         var firstLegalCharacter = GetIndexOfFirstLetter(input);
         input = input[firstLegalCharacter..];
 
-        return Regex.Replace(input, @"/^[^a-z]+|[^\w:-]+", "-");
+        return SanitizeHtmlIdRegEx().Replace(input, "-");
     }
 
     /// <summary>
@@ -46,4 +46,7 @@ public static class StringExtensions
 
         return input.Length;
     }
+
+    [GeneratedRegex(@"/^[^a-z]+|[^\w:-]+")]
+    private static partial Regex SanitizeHtmlIdRegEx();
 }

--- a/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
+++ b/src/Cake.Issues.Reporting.Sarif/SarifIssueReportGenerator.cs
@@ -236,7 +236,7 @@ internal class SarifIssueReportGenerator : IssueReportFormat
     /// <summary>
     /// Contains the <see cref="BaselineState"/> and <see cref="IIssue"/>.
     /// </summary>
-    private class SarifIssue
+    private sealed class SarifIssue
     {
         /// <summary>
         /// Gets the BaselineState for the <see cref="SarifIssue"/>.

--- a/src/Cake.Issues.Tests/IssuesArgumentChecksTests.cs
+++ b/src/Cake.Issues.Tests/IssuesArgumentChecksTests.cs
@@ -288,7 +288,7 @@ public sealed class IssuesArgumentChecksTests
             var values = new List<string> { value };
 
             // When
-            values.NotNullOrEmpty("foo");
+            values.NotNullOrEmpty();
 
             // Then
         }
@@ -330,7 +330,7 @@ public sealed class IssuesArgumentChecksTests
             var value = new List<int>();
 
             // When
-            value.NotNullOrEmptyElement("foo");
+            value.NotNullOrEmptyElement();
 
             // Then
         }
@@ -340,12 +340,13 @@ public sealed class IssuesArgumentChecksTests
         {
             // Given
             var value = new List<string> { null };
+            const string parameterName = "foo";
 
             // When
-            var result = Record.Exception(() => value.NotNullOrEmptyElement("foo"));
+            var result = Record.Exception(() => value.NotNullOrEmptyElement(parameterName));
 
             // Then
-            result.IsArgumentOutOfRangeException("foo");
+            result.IsArgumentOutOfRangeException(parameterName);
         }
 
         [Theory]
@@ -357,7 +358,7 @@ public sealed class IssuesArgumentChecksTests
             var values = new List<string> { value };
 
             // When
-            values.NotNullOrEmptyElement("foo");
+            values.NotNullOrEmptyElement();
 
             // Then
         }
@@ -455,7 +456,7 @@ public sealed class IssuesArgumentChecksTests
             var values = new List<string> { value };
 
             // When
-            values.NotNullOrEmptyOrEmptyElement("foo");
+            values.NotNullOrEmptyOrEmptyElement();
 
             // Then
         }

--- a/src/Cake.Issues/IIssueComparer.cs
+++ b/src/Cake.Issues/IIssueComparer.cs
@@ -95,7 +95,7 @@ public class IIssueComparer(IIssueProperty ignoredProperties) : IEqualityCompare
     /// <inheritdoc/>
     public int GetHashCode(IIssue obj)
     {
-        obj.NotNull(nameof(obj));
+        obj.NotNull();
 
         var valuesToHash = new List<object>();
 


### PR DESCRIPTION
Fixes linting issues:

* Use static readonly fields instead constant arrays (CA1861)
* Use generic overload (CA2263)
* Use GeneratedRegexAttribute (SYSLIB1045)
* Remove useless ToList calls (S2971)
* Seal not inherited private classes (S3260)
* Use caller information (S3236)
* Make private methods static (S2325)