### PR TITLE
Update test images

### DIFF
--- a/src/Images/Dockerfile.net8-bookworm
+++ b/src/Images/Dockerfile.net8-bookworm
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0.401-1-bookworm-slim@sha256:1e8c6666f3e31f96d22a5c77054589f85078a4850595421c6999395f26e79b9a
+FROM mcr.microsoft.com/dotnet/sdk:8.0.404-bookworm-slim@sha256:032381bcea86fa0a408af5df63a930f1ff5b03116c940a7cd744d3b648e66749
 
 RUN wget https://aka.ms/getvsdbgsh && \
     sh getvsdbgsh -v latest  -l /vsdbg

--- a/src/Images/Dockerfile.net9-bookworm
+++ b/src/Images/Dockerfile.net9-bookworm
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100-1-bookworm-slim@sha256:7d24e90a392e88eb56093e4eb325ff883ad609382a55d42f17fd557b997022ca
+FROM mcr.microsoft.com/dotnet/sdk:9.0.101-bookworm-slim@sha256:fe8ceeca5ee197deba95419e3b85c32744970b730ae11645e13f1cb74a848d98
 
 RUN wget https://aka.ms/getvsdbgsh && \
     sh getvsdbgsh -v latest  -l /vsdbg


### PR DESCRIPTION
Update test images to latest version.

This should also fix Renovate warnings.