### PR TITLE
Fix dependencies for Cake.Frosting.Issues.PullRequests.AppVeyor

### DIFF
--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AppVeyor.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AppVeyor.nuspec
@@ -30,11 +30,11 @@ For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.AppVe
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.0.0-beta.1</releaseNotes>
     <dependencies>
       <group targetFramework="net8.0">
-        <dependency id="Cake.Common" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Common" version="5.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Frosting.Issues.PullRequests" version="[5.0.0-beta0001,6.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Cake.Common" version="4.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Common" version="5.0" exclude="Build,Analyzers" />
         <dependency id="Cake.Frosting.Issues.PullRequests" version="[5.0.0-beta0001,6.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>


### PR DESCRIPTION
Fixes dependencies to `Cake.Common` in Cake.Frosting.Issues.PullRequests.AppVeyor