### PR TITLE
Remove no longer required CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cakeissues.net


### PR DESCRIPTION
Remove no longer required CNAME file on `develop` branch, since documentation now lives in the `gh-pages` branch