### PR TITLE
Use annotation for pinning note

### DIFF
--- a/docs/docs/documentation/issue-providers/docfx/examples.md
+++ b/docs/docs/documentation/issue-providers/docfx/examples.md
@@ -10,21 +10,19 @@ To call [DocFx](https://dotnet.github.io/docfx/){target="_blank"} from a Cake sc
 use the [Cake.DocFx](https://cakebuild.net/extensions/cake-docfx/){target="_blank"} addin.
 
 ```csharp
-#addin "Cake.DocFx"
+#addin "Cake.DocFx" // (1)!
 ```
+
+--8<-- "snippets/pinning.md"
 
 To read issues from DocFx log files you need to import the core addin and the DocFx support:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.DocFx"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 We need some global variables:
 

--- a/docs/docs/documentation/issue-providers/gitrepository/examples.md
+++ b/docs/docs/documentation/issue-providers/gitrepository/examples.md
@@ -13,15 +13,11 @@ The following example prints the number of binary files which are not tracked by
 To analyze Git repositories you need to import the core addin and the Git repository support:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.GitRepository"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 We need some global variables:
 

--- a/docs/docs/documentation/issue-providers/inspectcode/examples.md
+++ b/docs/docs/documentation/issue-providers/inspectcode/examples.md
@@ -8,21 +8,19 @@ The following example will call [JetBrains InspectCode] and output the number of
 To call [JetBrains InspectCode] from a Cake script you need to add the `JetBrains.ReSharper.CommandLineTools`:
 
 ```csharp
-#tool "nuget:?package=JetBrains.ReSharper.CommandLineTools"
+#tool "nuget:?package=JetBrains.ReSharper.CommandLineTools" // (1)!
 ```
+
+--8<-- "snippets/pinning.md"
 
 To read issues from InspectCode log files you need to import the core addin and the InspectCode support:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.InspectCode"
 ```
 
-!!! warning
-    Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the packages.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 We need some global variables:
 

--- a/docs/docs/documentation/issue-providers/markdownlint/examples.md
+++ b/docs/docs/documentation/issue-providers/markdownlint/examples.md
@@ -8,21 +8,19 @@ The following example will call [markdownlint-cli] to lint some markdown files a
 To call [markdownlint-cli] from a Cake script you can use the [Cake.Markdownlint] addin.
 
 ```csharp
-#addin "Cake.Markdownlint"
+#addin "Cake.Markdownlint" // (1)!
 ```
+
+--8<-- "snippets/pinning.md"
 
 To read issues from markdownlint-cli log files you need to import the core addin and the markdownlint support:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.Markdownlint"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 We need some global variables:
 

--- a/docs/docs/documentation/issue-providers/msbuild/examples.md
+++ b/docs/docs/documentation/issue-providers/msbuild/examples.md
@@ -8,22 +8,20 @@ The following example will call MsBuild to build the solution and outputs the nu
 To read issues from MsBuild log files you need to import the core addin and the MsBuild support:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.MsBuild"
 ```
+
+--8<-- "snippets/pinning.md"
 
 In this example the log file is written by the `XmlFileLogger` class from [MSBuild Extension Pack].
 In order to use the above logger, the following line will download and install the tool from NuGet.org:
 
 ```csharp
-#tool "nuget:?package=MSBuild.Extension.Pack"
+#tool "nuget:?package=MSBuild.Extension.Pack" // (1)!
 ```
 
-!!! warning
-    Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the packages.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 We need some global variables:
 

--- a/docs/docs/documentation/pull-request-systems/appveyor/examples/write-messages.md
+++ b/docs/docs/documentation/pull-request-systems/appveyor/examples/write-messages.md
@@ -10,17 +10,13 @@ the core pull request addin, the AppVeyor support and one or more issue provider
 in this example for JetBrains InspectCode:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.InspectCode"
 #addin "Cake.Issues.PullRequests"
 #addin "Cake.Issues.PullRequests.AppVeyor"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 In the following task we'll first determine the remote repository URL and
 source branch of the pull request and with this information call the

--- a/docs/docs/documentation/pull-request-systems/azure-devops/examples/azure-pipelines.md
+++ b/docs/docs/documentation/pull-request-systems/azure-devops/examples/azure-pipelines.md
@@ -10,18 +10,14 @@ the core pull request addin, the Azure DevOps support including the Cake.AzureDe
 in this example for JetBrains InspectCode:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.InspectCode"
 #addin "Cake.Issues.PullRequests"
 #addin "Cake.Issues.PullRequests.AzureDevOps"
 #addin "Cake.AzureDevOps"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 In the following task we'll first determine if the build is running on Azure DevOps and for a pull request,
 then read the remote repository URL and pull request id from environment variables set by the Azure Pipelines build

--- a/docs/docs/documentation/pull-request-systems/azure-devops/examples/pullrequest-id.md
+++ b/docs/docs/documentation/pull-request-systems/azure-devops/examples/pullrequest-id.md
@@ -16,18 +16,14 @@ the core pull request addin, the Azure DevOps support including the Cake.AzureDe
 in this example for JetBrains InspectCode:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.InspectCode"
 #addin "Cake.Issues.PullRequests"
 #addin "Cake.Issues.PullRequests.AzureDevOps"
 #addin "Cake.AzureDevOps"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 In the following task we'll first determine the remote repository URL and
 with this information call the [AzureDevOpsPullRequests](https://cakebuild.net/api/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemAliases/){target="_blank"}

--- a/docs/docs/documentation/pull-request-systems/azure-devops/examples/repository-information.md
+++ b/docs/docs/documentation/pull-request-systems/azure-devops/examples/repository-information.md
@@ -17,18 +17,14 @@ the core pull request addin, the Azure DevOps support including the Cake.AzureDe
 in this example for JetBrains InspectCode:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.InspectCode"
 #addin "Cake.Issues.PullRequests"
 #addin "Cake.Issues.PullRequests.AzureDevOps"
 #addin "Cake.AzureDevOps"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 In the following task we'll first determine the remote repository URL and
 source branch of the pull request and with this information call the [AzureDevOpsPullRequests](https://cakebuild.net/api/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemAliases/){target="_blank"}

--- a/docs/docs/documentation/pull-request-systems/github-actions/examples/write-annotations.md
+++ b/docs/docs/documentation/pull-request-systems/github-actions/examples/write-annotations.md
@@ -10,17 +10,13 @@ the core pull request addin, the GitHub Actions support and one or more issue pr
 in this example for JetBrains InspectCode:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.InspectCode"
 #addin "Cake.Issues.PullRequests"
 #addin "Cake.Issues.PullRequests.GitHubActions"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 In the following task we'll first determine the remote repository URL and
 source branch of the pull request and with this information call the

--- a/docs/docs/documentation/report-formats/console/examples.md
+++ b/docs/docs/documentation/report-formats/console/examples.md
@@ -5,14 +5,8 @@ description: Examples for using the Cake.Issues.Reporting.Console addin.
 
 The following example will print issues logged as warnings by MsBuild to the console.
 
-!!! warning
-    Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the packages.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
-
 ```csharp
-#tool "nuget:?package=MSBuild.Extension.Pack"
+#tool "nuget:?package=MSBuild.Extension.Pack" // (1)!
 #addin "Cake.Issues"
 #addin "Cake.Issues.MsBuild"
 #addin "Cake.Issues.Reporting"
@@ -54,3 +48,5 @@ Task("Create-IssueReport").Does(() =>
         string.Empty);
 });
 ```
+
+--8<-- "snippets/pinning.md"

--- a/docs/docs/documentation/report-formats/generic/examples/custom-template.md
+++ b/docs/docs/documentation/report-formats/generic/examples/custom-template.md
@@ -9,14 +9,8 @@ description: Example how to create a report using a custom template
 
 The following example will create a HTML report for issues logged as warnings by MsBuild using a custom template.
 
-!!! warning
-    Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the packages.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
-
 ```csharp
-#tool "nuget:?package=MSBuild.Extension.Pack"
+#tool "nuget:?package=MSBuild.Extension.Pack" // (1)!
 #addin "Cake.Issues"
 #addin "Cake.Issues.MsBuild"
 #addin "Cake.Issues.Reporting"
@@ -52,6 +46,8 @@ Task("Create-IssueReport").Does(() =>
         @"c:\report.html");
 });
 ```
+
+--8<-- "snippets/pinning.md"
 
 `ReportTemplate` looks like this:
 

--- a/docs/docs/documentation/report-formats/generic/examples/default-template.md
+++ b/docs/docs/documentation/report-formats/generic/examples/default-template.md
@@ -5,14 +5,8 @@ description: Example how to create a report using an embedded default template.
 
 The following example will create a HTML report for issues logged as warnings by MsBuild.
 
-!!! warning
-    Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the packages.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
-
 ```csharp
-#tool "nuget:?package=MSBuild.Extension.Pack"
+#tool "nuget:?package=MSBuild.Extension.Pack" // (1)!
 #addin "Cake.Issues"
 #addin "Cake.Issues.MsBuild"
 #addin "Cake.Issues.Reporting"
@@ -48,3 +42,5 @@ Task("Create-IssueReport").Does(() =>
         @"c:\report.html");
 });
 ```
+
+--8<-- "snippets/pinning.md"

--- a/docs/docs/documentation/report-formats/sarif/examples.md
+++ b/docs/docs/documentation/report-formats/sarif/examples.md
@@ -5,14 +5,8 @@ description: Examples for using the Cake.Issues.Reporting.Sarif addin.
 
 The following example will create a SARIF report for issues logged as warnings by MsBuild.
 
-!!! warning
-    Please note that you always should pin addins and tools to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the packages.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
-
 ```csharp
-#tool "nuget:?package=MSBuild.Extension.Pack"
+#tool "nuget:?package=MSBuild.Extension.Pack" // (1)!
 #addin "Cake.Issues"
 #addin "Cake.Issues.MsBuild"
 #addin "Cake.Issues.Reporting"
@@ -48,3 +42,5 @@ Task("Create-IssueReport").Does(() =>
         @"c:\report.sarif");
 });
 ```
+
+--8<-- "snippets/pinning.md"

--- a/docs/docs/documentation/usage/creating-issues/creating-issues.md
+++ b/docs/docs/documentation/usage/creating-issues/creating-issues.md
@@ -9,14 +9,10 @@ This issues can for example be used to create reports.
 To create issues you need to import the following core addin:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 In the following task a new warning for the myfile.txt file on line 42 is created:
 

--- a/docs/docs/documentation/usage/creating-reports/creating-reports.md
+++ b/docs/docs/documentation/usage/creating-reports/creating-reports.md
@@ -6,24 +6,22 @@ description: Usage instructions how to create reports.
 To create report for issues you need to import the following core addins:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.Reporting"
 ```
+
+--8<-- "snippets/pinning.md"
 
 Also you need to import at least one issue provider and report format.
 In the following example the issue provider for reading warnings from MsBuild log files
 and generic report format is imported:
 
 ```csharp
-#addin "Cake.Issues.MsBuild"
+#addin "Cake.Issues.MsBuild" // (1)!
 #addin "Cake.Issues.Reporting.Generic"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 Finally you can define a task where you call the reporting addin with the desired issue provider and report format:
 

--- a/docs/docs/documentation/usage/reading-issues/reading-issues.md
+++ b/docs/docs/documentation/usage/reading-issues/reading-issues.md
@@ -9,23 +9,21 @@ This can for example be useful to break builds based on the reported issues.
 To read issues you need to import the following core addin:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 ```
+
+--8<-- "snippets/pinning.md"
 
 Also you need to import at least one issue provider.
 In the following example the issue providers for reading warnings from MsBuild log files
 and from JetBrains InspectCode are imported:
 
 ```csharp
-#addin "Cake.Issues.MsBuild"
+#addin "Cake.Issues.MsBuild" // (1)!
 #addin "Cake.Issues.InspectCode"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 Finally you can define a task where you call the core addin with the desired issue providers.
 The following example reads issues reported as MsBuild warnings by the `XmlFileLogger`

--- a/docs/docs/documentation/usage/reporting-issues-to-pull-requests/custom-issue-filter.md
+++ b/docs/docs/documentation/usage/reporting-issues-to-pull-requests/custom-issue-filter.md
@@ -14,14 +14,8 @@ You can define custom filters which are applied to issues before they are posted
 
 The following example will filter out all issues from the rule `CA1000` from being posted to the pull request.
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
-
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.MsBuild"
 #addin "Cake.Issues.PullRequests"
 #addin "Cake.Issues.PullRequests.AzureDevOps"
@@ -49,3 +43,5 @@ Task("ReportIssuesToPullRequest").Does(() =>
         settings));
 });
 ```
+
+--8<-- "snippets/pinning.md"

--- a/docs/docs/documentation/usage/reporting-issues-to-pull-requests/report-issues-to-pull-requests.md
+++ b/docs/docs/documentation/usage/reporting-issues-to-pull-requests/report-issues-to-pull-requests.md
@@ -6,24 +6,22 @@ description: Usage instructions how to report issues to pull requests.
 To use report issues to pull requests you need to import the following core addins:
 
 ```csharp
-#addin "Cake.Issues"
+#addin "Cake.Issues" // (1)!
 #addin "Cake.Issues.PullRequests"
 ```
+
+--8<-- "snippets/pinning.md"
 
 Also you need to import at least one issue provider and pull request system.
 In the following example the issue provider for reading warnings from MsBuild log files
 and support for Azure DevOps pull requests is imported:
 
 ```csharp
-#addin "Cake.Issues.MsBuild"
+#addin "Cake.Issues.MsBuild" // (1)!
 #addin "Cake.Issues.PullRequests.AzureDevOps"
 ```
 
-!!! warning
-    Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
-    won't break due to updates to one of the addins.
-
-    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.
+--8<-- "snippets/pinning.md"
 
 Finally you can define a task where you call the core addin with the desired issue provider and pull request system:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,6 +46,7 @@ theme:
         name: Switch to system preference
   features:
     - content.action.edit
+    - content.code.annotate
     - content.code.copy
     - navigation.indexes 
     - navigation.instant

--- a/docs/snippets/pinning.md
+++ b/docs/snippets/pinning.md
@@ -1,0 +1,4 @@
+1.  Please note that you always should pin addins to a specific version to make sure your builds are deterministic and
+    won't break due to updates to one of the addins.
+
+    See [pinning addin versions](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.


### PR DESCRIPTION
Switches to use annotations for note regarding addin and tool pinning. Also uses a shared snippet to avoid repeated documentation.