### PR TITLE
Improve issue provider overview pages

### DIFF
--- a/docs/docs/documentation/issue-providers/docfx/examples.md
+++ b/docs/docs/documentation/issue-providers/docfx/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Examples
 description: Examples for using the Cake.Issues.DocFx addin.
+icon: material/test-tube
 ---
 
 The following example will call [DocFx](https://dotnet.github.io/docfx/){target="_blank"} to

--- a/docs/docs/documentation/issue-providers/docfx/features.md
+++ b/docs/docs/documentation/issue-providers/docfx/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.DocFx addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.DocFx addin](https://cakebuild.net/extensions/cake-issues-docfx/){target="_blank"}

--- a/docs/docs/documentation/issue-providers/docfx/index.md
+++ b/docs/docs/documentation/issue-providers/docfx/index.md
@@ -5,3 +5,10 @@ description: Issue provider which allows you to read warnings logged by DocFx.
 
 Support for reading warnings reported by [DocFx](https://dotnet.github.io/docfx/){target="_blank"} is implemented in the
 [Cake.Issues.DocFx addin](https://cakebuild.net/extensions/cake-issues-docfx/){target="_blank"}.
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+- :material-test-tube: [Examples](examples.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/eslint/features.md
+++ b/docs/docs/documentation/issue-providers/eslint/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.EsLint addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.EsLint addin](https://cakebuild.net/extensions/cake-issues-eslint/){target="_blank"} provides the following features.

--- a/docs/docs/documentation/issue-providers/eslint/index.md
+++ b/docs/docs/documentation/issue-providers/eslint/index.md
@@ -5,3 +5,9 @@ description: Issue provider which allows you to read issues logged by ESLint.
 
 Support for reading issues reported by [ESLint](https://eslint.org/){target="_blank"}
 is implemented in the [Cake.Issues.EsLint addin](https://cakebuild.net/extensions/cake-issues-eslint/){target="_blank"}.
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/gitrepository/examples.md
+++ b/docs/docs/documentation/issue-providers/gitrepository/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Examples
 description: Examples for using the Cake.Issues.GitRepository addin.
+icon: material/test-tube
 ---
 
 The following example prints the number of binary files which are not tracked by

--- a/docs/docs/documentation/issue-providers/gitrepository/features.md
+++ b/docs/docs/documentation/issue-providers/gitrepository/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.GitRepository addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.GitRepository addin](https://cakebuild.net/extensions/cake-issues-gitrepository/){target="_blank"}

--- a/docs/docs/documentation/issue-providers/gitrepository/index.md
+++ b/docs/docs/documentation/issue-providers/gitrepository/index.md
@@ -5,3 +5,11 @@ description: Issue provider which allows you to analyzing Git repositories and c
 
 Support for analyzing Git repositories is implemented in the
 [Cake.Issues.GitRepository addin](https://cakebuild.net/extensions/cake-issues-gitrepository/){target="_blank"}.
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+- :material-test-tube: [Examples](examples.md)
+- :fontawesome-solid-scroll: [Rules](rules/index.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/gitrepository/rules/index.md
+++ b/docs/docs/documentation/issue-providers/gitrepository/rules/index.md
@@ -1,0 +1,12 @@
+---
+title: Rules
+description: Rules of the Cake.Issues.GitRepository provider.
+icon: fontawesome/solid/scroll
+---
+
+<div class="grid cards" markdown>
+
+- :fontawesome-solid-scroll: [BinaryFileNotTrackedByLfs](BinaryFileNotTrackedByLfs.md)
+- :fontawesome-solid-scroll: [FilePathTooLong](FilePathTooLong.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/inspectcode/examples.md
+++ b/docs/docs/documentation/issue-providers/inspectcode/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Examples
 description: Examples for using the Cake.Issues.InspectCode addin.
+icon: material/test-tube
 ---
 
 The following example will call [JetBrains InspectCode] and output the number of warnings.

--- a/docs/docs/documentation/issue-providers/inspectcode/features.md
+++ b/docs/docs/documentation/issue-providers/inspectcode/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.InspectCode addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.InspectCode addin]{target="_blank"} provides the following features.

--- a/docs/docs/documentation/issue-providers/inspectcode/index.md
+++ b/docs/docs/documentation/issue-providers/inspectcode/index.md
@@ -5,3 +5,10 @@ description: Issue provider which allows you to read issues logged by JetBrains 
 
 Support for reading issues reported by [JetBrains Inspect Code](https://www.jetbrains.com/help/resharper/2017.1/InspectCode.html)
 is implemented in the [Cake.Issues.InspectCode addin](https://www.nuget.org/packages/Cake.Issues.InspectCode).
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+- :material-test-tube: [Examples](examples.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/markdownlint/examples.md
+++ b/docs/docs/documentation/issue-providers/markdownlint/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Examples
 description: Examples for using the Cake.Issues.Markdownlint addin.
+icon: material/test-tube
 ---
 
 The following example will call [markdownlint-cli] to lint some markdown files and outputs the number of warnings.

--- a/docs/docs/documentation/issue-providers/markdownlint/features.md
+++ b/docs/docs/documentation/issue-providers/markdownlint/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.Markdownlint addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.Markdownlint addin](https://cakebuild.net/extensions/cake-issues-markdownlint/){target="_blank"}

--- a/docs/docs/documentation/issue-providers/markdownlint/index.md
+++ b/docs/docs/documentation/issue-providers/markdownlint/index.md
@@ -5,3 +5,10 @@ description: Issue provider which allows you to read issues logged by markdownli
 
 Support for reading issues reported by [markdownlint](https://github.com/DavidAnson/markdownlint)
 is implemented in the [Cake.Issues.Markdownlint addin](https://www.nuget.org/packages/Cake.Issues.Markdownlint).
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+- :material-test-tube: [Examples](examples.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/msbuild/examples.md
+++ b/docs/docs/documentation/issue-providers/msbuild/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Examples
 description: Examples for using the Cake.Issues.MsBuild addin.
+icon: material/test-tube
 ---
 
 The following example will call MsBuild to build the solution and outputs the number of warnings.

--- a/docs/docs/documentation/issue-providers/msbuild/features.md
+++ b/docs/docs/documentation/issue-providers/msbuild/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.MsBuild addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.MsBuild addin](https://cakebuild.net/extensions/cake-issues-msbuild/){target="_blank"}

--- a/docs/docs/documentation/issue-providers/msbuild/index.md
+++ b/docs/docs/documentation/issue-providers/msbuild/index.md
@@ -5,3 +5,10 @@ description: Issue provider which allows you to read warnings logged by MsBuild.
 
 Support for reading warnings reported by MsBuild is implemented in the
 [Cake.Issues.MsBuild](https://www.nuget.org/packages/Cake.Issues.MsBuild).
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+- :material-test-tube: [Examples](examples.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/sarif/features.md
+++ b/docs/docs/documentation/issue-providers/sarif/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.Sarif addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.Sarif addin](https://cakebuild.net/extensions/cake-issues-terraform/){target="_blank"} provides the following features.

--- a/docs/docs/documentation/issue-providers/sarif/index.md
+++ b/docs/docs/documentation/issue-providers/sarif/index.md
@@ -5,3 +5,9 @@ description: Issue provider which allows you to read issues from SARIF files.
 
 Support for reading issues in [SARIF](https://sarifweb.azurewebsites.net/){target="_blank"} format
 is implemented in the [Cake.Issues.Sarif addin](https://cakebuild.net/extensions/cake-issues-sarif/){target="_blank"}.
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+
+</div>

--- a/docs/docs/documentation/issue-providers/terraform/features.md
+++ b/docs/docs/documentation/issue-providers/terraform/features.md
@@ -1,6 +1,7 @@
 ---
 title: Features
 description: Features of the Cake.Issues.Terraform addin.
+icon: material/creation-outline
 ---
 
 The [Cake.Issues.Terraform addin]{target="_blank"} provides the following features.

--- a/docs/docs/documentation/issue-providers/terraform/index.md
+++ b/docs/docs/documentation/issue-providers/terraform/index.md
@@ -5,3 +5,9 @@ description: Issue provider which allows you to read issues from Terraform valid
 
 Support for reading issues reported by [Terraform validate command](https://www.terraform.io/docs/cli/commands/validate.html)
 is implemented in the [Cake.Issues.Terraform addin](https://cakebuild.net/extensions/cake-issues-terraform/).
+
+<div class="grid cards" markdown>
+
+- :material-creation-outline: [Features](features.md)
+
+</div>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
           - Features: documentation/issue-providers/gitrepository/features.md
           - Examples: documentation/issue-providers/gitrepository/examples.md
           - Rules:
+            - documentation/issue-providers/gitrepository/rules/index.md
             - BinaryFileNotTrackedByLfs: documentation/issue-providers/gitrepository/rules/BinaryFileNotTrackedByLfs.md
             - FilePathTooLong: documentation/issue-providers/gitrepository/rules/FilePathTooLong.md
         - InspectCode:


### PR DESCRIPTION
Improve issue provider overview pages by linking to sub-pages and adding icons to sub-pages