### PR TITLE
Improve API documentation links

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -1,0 +1,51 @@
+---
+title: API
+description: Cake.Issues API documentation
+hide:
+  - navigation
+---
+
+## Core Addins
+
+<div class="grid cards" markdown>
+
+- [Cake.Issues](https://cakebuild.net/extensions/cake-issues){target="_blank"}
+- [Cake.Issues.Reporting](https://cakebuild.net/extensions/cake-issues-reporting){target="_blank"}
+- [Cake.Issues.PullRequests](https://cakebuild.net/extensions/cake-issues-pullrequests){target="_blank"}
+
+</div>
+
+## Issue Provider
+
+<div class="grid cards" markdown>
+
+- [Cake.Issues.DocFx](https://cakebuild.net/extensions/cake-issues-docfx){target="_blank"}
+- [Cake.Issues.EsLint](https://cakebuild.net/extensions/cake-issues-eslint){target="_blank"}
+- [Cake.Issues.GitRepository](https://cakebuild.net/extensions/cake-issues-gitrepository){target="_blank"}
+- [Cake.Issues.InspectCode](https://cakebuild.net/extensions/cake-issues-inspectcode){target="_blank"}
+- [Cake.Issues.Markdownlint](https://cakebuild.net/extensions/cake-issues-markdownlint){target="_blank"}
+- [Cake.Issues.MsBuild](https://cakebuild.net/extensions/cake-issues-msbuild){target="_blank"}
+- [Cake.Issues.Sarif](https://cakebuild.net/extensions/cake-issues-sarif){target="_blank"}
+- [Cake.Issues.Terraform](https://cakebuild.net/extensions/cake-issues-terraform){target="_blank"}
+
+</div>
+
+## Report Formats
+
+<div class="grid cards" markdown>
+
+- [Cake.Issues.Reporting.Console](https://cakebuild.net/extensions/cake-issues-reporting-console){target="_blank"}
+- [Cake.Issues.Reporting.Generic](https://cakebuild.net/extensions/cake-issues-reporting-Generic){target="_blank"}
+- [Cake.Issues.Reporting.Sarif](https://cakebuild.net/extensions/cake-issues-reporting-Sarif){target="_blank"}
+
+</div>
+
+## Pull Request Systems
+
+<div class="grid cards" markdown>
+
+- [Cake.Issues.PullRequests.AppVeyor](https://cakebuild.net/extensions/cake-issues-pullrequests-appveyor){target="_blank"}
+- [Cake.Issues.PullRequests.AzureDevOps](https://cakebuild.net/extensions/cake-issues-pullrequests-azuredevops){target="_blank"}
+- [Cake.Issues.PullRequests.GitHubActions](https://cakebuild.net/extensions/cake-issues-pullrequests-githubactions){target="_blank"}
+
+</div>

--- a/docs/docs/documentation/issue-providers/docfx/index.md
+++ b/docs/docs/documentation/issue-providers/docfx/index.md
@@ -10,5 +10,6 @@ Support for reading warnings reported by [DocFx](https://dotnet.github.io/docfx/
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-docfx){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/eslint/index.md
+++ b/docs/docs/documentation/issue-providers/eslint/index.md
@@ -9,5 +9,6 @@ is implemented in the [Cake.Issues.EsLint addin](https://cakebuild.net/extension
 <div class="grid cards" markdown>
 
 - :material-creation-outline: [Features](features.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-eslint){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/gitrepository/index.md
+++ b/docs/docs/documentation/issue-providers/gitrepository/index.md
@@ -11,5 +11,6 @@ Support for analyzing Git repositories is implemented in the
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
 - :fontawesome-solid-scroll: [Rules](rules/index.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-gitrepository){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/inspectcode/index.md
+++ b/docs/docs/documentation/issue-providers/inspectcode/index.md
@@ -10,5 +10,6 @@ is implemented in the [Cake.Issues.InspectCode addin](https://www.nuget.org/pack
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-inspectcode){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/markdownlint/index.md
+++ b/docs/docs/documentation/issue-providers/markdownlint/index.md
@@ -10,5 +10,6 @@ is implemented in the [Cake.Issues.Markdownlint addin](https://www.nuget.org/pac
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-markdownlint){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/msbuild/index.md
+++ b/docs/docs/documentation/issue-providers/msbuild/index.md
@@ -10,5 +10,6 @@ Support for reading warnings reported by MsBuild is implemented in the
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-msbuild){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/sarif/index.md
+++ b/docs/docs/documentation/issue-providers/sarif/index.md
@@ -9,5 +9,6 @@ is implemented in the [Cake.Issues.Sarif addin](https://cakebuild.net/extensions
 <div class="grid cards" markdown>
 
 - :material-creation-outline: [Features](features.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-sarif){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/issue-providers/terraform/index.md
+++ b/docs/docs/documentation/issue-providers/terraform/index.md
@@ -9,5 +9,6 @@ is implemented in the [Cake.Issues.Terraform addin](https://cakebuild.net/extens
 <div class="grid cards" markdown>
 
 - :material-creation-outline: [Features](features.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-terraform){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/pull-request-systems/appveyor/index.md
+++ b/docs/docs/documentation/pull-request-systems/appveyor/index.md
@@ -10,5 +10,6 @@ Support for AppVeyor is implemented in the
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples/index.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-pullrequests-appveyor){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/pull-request-systems/azure-devops/index.md
+++ b/docs/docs/documentation/pull-request-systems/azure-devops/index.md
@@ -11,5 +11,6 @@ Support for Azure DevOps is implemented in the
 - :material-creation-outline: [Features](features.md)
 - :material-cogs: [Setup](setup.md)
 - :material-test-tube: [Examples](examples/index.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-pullrequests-azuredevops){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/pull-request-systems/github-actions/index.md
+++ b/docs/docs/documentation/pull-request-systems/github-actions/index.md
@@ -10,5 +10,6 @@ Support for GitHub Actions is implemented in the
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples/index.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-pullrequests-githubactions){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/report-formats/console/index.md
+++ b/docs/docs/documentation/report-formats/console/index.md
@@ -10,5 +10,6 @@ a [Cake.Issues.Reporting.Console addin](https://cakebuild.net/extensions/cake-is
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-reporting-console){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/report-formats/generic/index.md
+++ b/docs/docs/documentation/report-formats/generic/index.md
@@ -11,5 +11,6 @@ Support for creating reports in any text based format like HTML or Markdown is i
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples/index.md)
 - :material-image: [Template Gallery](templates/index.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-reporting-generic){target="_blank"}
 
 </div>

--- a/docs/docs/documentation/report-formats/sarif/index.md
+++ b/docs/docs/documentation/report-formats/sarif/index.md
@@ -10,5 +10,6 @@ Support for creating SARIF compatible reports is implemented in the
 
 - :material-creation-outline: [Features](features.md)
 - :material-test-tube: [Examples](examples.md)
+- :material-api: [API](https://cakebuild.net/extensions/cake-issues-reporting-sarif){target="_blank"}
 
 </div>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -153,9 +153,11 @@ nav:
           - documentation/issue-providers/docfx/index.md
           - Features: documentation/issue-providers/docfx/features.md
           - Examples: documentation/issue-providers/docfx/examples.md
+          - API: https://cakebuild.net/extensions/cake-issues-docfx" target="_blank
         - ESLint:
           - documentation/issue-providers/eslint/index.md
           - Features: documentation/issue-providers/eslint/features.md
+          - API: https://cakebuild.net/extensions/cake-issues-eslint" target="_blank
         - Git Repository:
           - documentation/issue-providers/gitrepository/index.md
           - Features: documentation/issue-providers/gitrepository/features.md
@@ -164,30 +166,37 @@ nav:
             - documentation/issue-providers/gitrepository/rules/index.md
             - BinaryFileNotTrackedByLfs: documentation/issue-providers/gitrepository/rules/BinaryFileNotTrackedByLfs.md
             - FilePathTooLong: documentation/issue-providers/gitrepository/rules/FilePathTooLong.md
+          - API: https://cakebuild.net/extensions/cake-issues-gitrepository" target="_blank
         - InspectCode:
           - documentation/issue-providers/inspectcode/index.md
           - Features: documentation/issue-providers/inspectcode/features.md
           - Examples: documentation/issue-providers/inspectcode/examples.md
+          - API: https://cakebuild.net/extensions/cake-issues-inspectcode" target="_blank
         - markdownlint:
           - documentation/issue-providers/markdownlint/index.md
           - Features: documentation/issue-providers/markdownlint/features.md
           - Examples: documentation/issue-providers/markdownlint/examples.md
+          - API: https://cakebuild.net/extensions/cake-issues-markdownlint" target="_blank
         - MsBuild:
           - documentation/issue-providers/msbuild/index.md
           - Features: documentation/issue-providers/msbuild/features.md
           - Examples: documentation/issue-providers/msbuild/examples.md
+          - API: https://cakebuild.net/extensions/cake-issues-msbuild" target="_blank
         - Sarif:
           - documentation/issue-providers/sarif/index.md
           - Features: documentation/issue-providers/sarif/features.md
+          - API: https://cakebuild.net/extensions/cake-issues-sarif" target="_blank
         - Terraform:
           - documentation/issue-providers/terraform/index.md
           - Features: documentation/issue-providers/terraform/features.md
+          - API: https://cakebuild.net/extensions/cake-issues-terraform" target="_blank
       - Report Formats:
         - documentation/report-formats/index.md
         - Console:
           - documentation/report-formats/console/index.md
           - Features: documentation/report-formats/console/features.md
           - Examples: documentation/report-formats/console/examples.md
+          - API: https://cakebuild.net/extensions/cake-issues-reporting-console" target="_blank
         - Generic:
           - documentation/report-formats/generic/index.md
           - Features: documentation/report-formats/generic/features.md
@@ -200,10 +209,12 @@ nav:
             - HTML DevExtreme Data Grid: documentation/report-formats/generic/templates/htmldxdatagrid.md
             - HTML Data Table: documentation/report-formats/generic/templates/htmldatatable.md
             - HTML Diagnostic: documentation/report-formats/generic/templates/htmldiagnostic.md
+          - API: https://cakebuild.net/extensions/cake-issues-reporting-generic" target="_blank
         - Sarif:
           - documentation/report-formats/sarif/index.md
           - Features: documentation/report-formats/sarif/features.md
           - Examples: documentation/report-formats/sarif/examples.md
+          - API: https://cakebuild.net/extensions/cake-issues-reporting-sarif" target="_blank
       - Pull Request Systems:
         - documentation/pull-request-systems/index.md
         - AppVeyor:
@@ -213,6 +224,7 @@ nav:
             - documentation/pull-request-systems/appveyor/examples/index.md
             - Writing Messages To AppVeyor: documentation/pull-request-systems/appveyor/examples/write-messages.md
             - GitHub Pull Request Integration: documentation/pull-request-systems/appveyor/examples/github-pullrequest-integration.md
+          - API: https://cakebuild.net/extensions/cake-issues-pullrequests-appveyor" target="_blank
         - Azure DevOps:
           - documentation/pull-request-systems/azure-devops/index.md
           - Features: documentation/pull-request-systems/azure-devops/features.md
@@ -222,12 +234,14 @@ nav:
             - Using With Pull Request ID: documentation/pull-request-systems/azure-devops/examples/pullrequest-id.md
             - Using With Repository Remote URL And Source Branch Name: documentation/pull-request-systems/azure-devops/examples/repository-information.md
             - Using With Azure Pipelines: documentation/pull-request-systems/azure-devops/examples/azure-pipelines.md
+          - API: https://cakebuild.net/extensions/cake-issues-pullrequests-azuredevops" target="_blank
         - GitHub Actions:
           - documentation/pull-request-systems/github-actions/index.md
           - Features: documentation/pull-request-systems/github-actions/features.md
           - Examples:
             - documentation/pull-request-systems/github-actions/examples/index.md
             - Create annotations in GitHub Actions: documentation/pull-request-systems/github-actions/examples/write-annotations.md
+          - API: https://cakebuild.net/extensions/cake-issues-pullrequests-githubactions" target="_blank
     - How To Develop:
       - Extending:
         - documentation/extending/index.md
@@ -255,5 +269,5 @@ nav:
     - Resources:
       - Blog Posts: documentation/resources/blog-posts.md
       - Presentations: documentation/resources/presentations.md
+  - API: api.md
   - Release Notes: https://github.com/cake-contrib/Cake.Issues/releases" target="_blank
-  - API: https://cakebuild.net/extensions/cake-issues/" target="_blank


### PR DESCRIPTION
Add link to API documentation on Cake website for every addin and introduce overall API page