### PR TITLE
Enable generation of social cards

### DIFF
--- a/.github/workflows/publish-develop-docs.yml
+++ b/.github/workflows/publish-develop-docs.yml
@@ -23,9 +23,11 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
         with:
           python-version: 3.13.1
-      - name: Install Dependencies
+      - name: Install Python Dependencies
         run: pip install -r requirements.txt
         working-directory: ./docs
+      - name: Install Required Libraries
+        run: apt-get install pngquant
       - name: Configure Git
         run: |
           git config --global user.name "Build Server"

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -22,9 +22,11 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
         with:
           python-version: 3.13.1
-      - name: Install Dependencies
+      - name: Install Python Dependencies
         run: pip install -r requirements.txt
         working-directory: ./docs
+      - name: Install Required Libraries
+        run: apt-get install pngquant
       - name: Configure Git
         run: |
           git config --global user.name "Build Server"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -71,6 +71,8 @@ plugins:
       post_readtime: true
   - macros
   - search
+  - social:
+      enabled: !ENV [GITHUB_ACTIONS, false]
   - table-reader
 
 # Extensions


### PR DESCRIPTION
Enables generation of social cards. Social cards are only generated when running in GitHub Actions, not when running locally.