### PR TITLE
Ensure Material for MkDocs imaging dependencies are installed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,5 @@ mike==2.1.3
 mkdocs==1.6.1
 mkdocs-macros-plugin==1.3.7
 mkdocs-material==9.5.49
+mkdocs-material[imaging]==9.5.49
 mkdocs-table-reader-plugin==3.1.0


### PR DESCRIPTION
Ensures Material for MkDocs imaging dependencies, which are required for social cards, are installed when running documentation build in pipeline.