### PR TITLE
Use nicer slugs for tab anchors

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -98,6 +98,9 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde


### PR DESCRIPTION
Improve slugs for content tabs to use tab name. Instead `#__tabbed_1_1` it will for example become `#cake-net-tool`