### PR TITLE
Use latest versions of NuGet packages in examples

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,18 @@
   "extends": [
     "github>cake-contrib/renovate-presets:cake-issues"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update versions of NuGet packages used in documentation",
+      "fileMatch": [
+        "docs/mkdocs.yml$"
+      ],
+      "matchStrings": [
+        "\\s*#\\srenovate:\\sdatasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s*.*?_version\\s*:\\s*(?<currentValue>.*)"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "description": "Ignore Cake runner minor and patch updates",

--- a/docs/input/documentation/issue-providers/docfx/examples.md
+++ b/docs/input/documentation/issue-providers/docfx/examples.md
@@ -11,12 +11,10 @@ To read issues from DocFx log files the DocFx issue provider needs to be importe
 === "Cake .NET Tool"
 
     ```csharp title="build.cake"
-    #addin "Cake.DocFx" // (1)!
+    #addin nuget:?package=Cake.DocFx&version={{ cake_docfx_version }}
     #addin nuget:?package=Cake.Issues&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.DocFx&version={{ cake_issues_version }}
     ```
-
-    --8<-- "snippets/pinning.md"
 
     !!! note
         In addition to the DocFx issue provider the `Cake.Issues` core addin needs to be added.
@@ -32,14 +30,12 @@ To read issues from DocFx log files the DocFx issue provider needs to be importe
         <ImplicitUsings>enable</ImplicitUsings>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Cake.DocFx" Version="1.0.0" /> // (1)!
+        <PackageReference Include="Cake.DocFx" Version="{{ cake_docfx_version }}" />
         <PackageReference Include="Cake.Frosting" Version="{{ cake_version }}" />
         <PackageReference Include="Cake.Frosting.Issues.DocFx" Version="{{ cake_issues_version }}" />
       </ItemGroup>
     </Project>
     ```
-
-    --8<-- "snippets/version-placeholder.md"
 
 The following example contains a task which will build the [DocFx](https://dotnet.github.io/docfx/){target="_blank"}
 project and write a log file and a task to read issues from the log file and write the number of warnings to the console:

--- a/docs/input/documentation/issue-providers/inspectcode/examples.md
+++ b/docs/input/documentation/issue-providers/inspectcode/examples.md
@@ -40,7 +40,7 @@ and write a log file and a task to read issues from the log file and write the n
 === "Cake .NET Tool"
 
     ```csharp title="build.cake"
-    #tool "nuget:?package=JetBrains.ReSharper.CommandLineTools" // (1)!
+    #tool "nuget:?package=JetBrains.ReSharper.CommandLineTools&version={{ resharper_commandlinetool_version }}"
 
     var logPath = @"c:\build\inspectcode.xml";
     var repoRootFolder = MakeAbsolute(Directory("./"));
@@ -69,8 +69,6 @@ and write a log file and a task to read issues from the log file and write the n
     });
     ```
 
-    --8<-- "snippets/pinning.md"
-
 === "Cake Frosting"
 
     ```csharp title="Program.cs"
@@ -88,7 +86,7 @@ and write a log file and a task to read issues from the log file and write the n
                 .UseContext<BuildContext>()
                 .InstallTool(
                 new Uri(
-                    "nuget:?package=JetBrains.ReSharper.CommandLineTools")) // (1)!
+                    "nuget:?package=JetBrains.ReSharper.CommandLineTools&version={{ resharper_commandlinetool_version }}"))
                 .Run(args);
         }
     }
@@ -132,7 +130,5 @@ and write a log file and a task to read issues from the log file and write the n
         }
     }
     ```
-
-    --8<-- "snippets/pinning.md"
 
 [JetBrains InspectCode]: https://www.jetbrains.com/help/resharper/InspectCode.html

--- a/docs/input/documentation/issue-providers/markdownlint/examples.md
+++ b/docs/input/documentation/issue-providers/markdownlint/examples.md
@@ -10,12 +10,10 @@ To read issues from markdownlint-cli log files the markdownlint issue provider n
 === "Cake .NET Tool"
 
     ```csharp title="build.cake"
-    #addin "Cake.Markdownlint" // (1)!
+    #addin nuget:?package=Cake.Markdownlint&version={{ cake_markdownlint_version }}
     #addin nuget:?package=Cake.Issues&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.Markdownlint&version={{ cake_issues_version }}
     ```
-
-    --8<-- "snippets/pinning.md"
 
     !!! note
         In addition to the markdownlint issue provider the `Cake.Issues` core addin needs to be added.
@@ -31,14 +29,12 @@ To read issues from markdownlint-cli log files the markdownlint issue provider n
         <ImplicitUsings>enable</ImplicitUsings>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Cake.Markdownlint" Version="1.0.0" /> // (1)!
+        <PackageReference Include="Cake.Markdownlint" Version="{{ cake_markdownlint_version }}" />
         <PackageReference Include="Cake.Frosting" Version="{{ cake_version }}" />
         <PackageReference Include="Cake.Frosting.Issues.Markdownlint" Version="{{ cake_issues_version }}" />
       </ItemGroup>
     </Project>
     ```
-
-    --8<-- "snippets/version-placeholder.md"
 
 The following example contains a task which will run [markdownlint-cli]{target="_blank"} and write a log file
 and a task to read issues from the log file and write the number of warnings to the console:

--- a/docs/input/documentation/pull-request-systems/azure-devops/examples/azure-pipelines.md
+++ b/docs/input/documentation/pull-request-systems/azure-devops/examples/azure-pipelines.md
@@ -13,10 +13,8 @@ For this example the JetBrains InspectCode issue provider is additionally used f
     #addin nuget:?package=Cake.Issues.InspectCode&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.PullRequests&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version={{ cake_issues_version }}
-    #addin "Cake.AzureDevOps" // (1)!
+    #addin nuget:?package=Cake.AzureDevOps&version={{ cake_azuredevops_version }}
     ```
-
-    --8<-- "snippets/pinning.md"
 
     !!! note
         In addition to the Azure DevOps pull request system the `Cake.Issues` and `Cake.Issues.PullRequests` core addins

--- a/docs/input/documentation/pull-request-systems/azure-devops/examples/pullrequest-id.md
+++ b/docs/input/documentation/pull-request-systems/azure-devops/examples/pullrequest-id.md
@@ -10,15 +10,13 @@ For this example the JetBrains InspectCode issue provider is additionally used f
 === "Cake .NET Tool"
 
     ```csharp title="build.cake"
-    #addin "Cake.Git" // (1)!
+    #addin nuget:?package=Cake.Git&version={{ cake_git_version }}
     #addin nuget:?package=Cake.Issues&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.InspectCode&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.PullRequests&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version={{ cake_issues_version }}
-    #addin "Cake.AzureDevOps" // (1)!
+    #addin nuget:?package=Cake.AzureDevOps&version={{ cake_azuredevops_version }}
     ```
-
-    --8<-- "snippets/pinning.md"
 
     !!! note
         In addition to the Azure DevOps pull request system the `Cake.Issues` and `Cake.Issues.PullRequests` core addins
@@ -36,14 +34,12 @@ For this example the JetBrains InspectCode issue provider is additionally used f
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Cake.Frosting" Version="{{ cake_version }}" />
-        <PackageReference Include="Cake.Frosting.Git" Version="1.0.0" /> // (1)!
+        <PackageReference Include="Cake.Frosting.Git" Version="{{ cake_git }}" />
         <PackageReference Include="Cake.Frosting.Issues.InspectCode" Version="{{ cake_issues_version }}" />
         <PackageReference Include="Cake.Frosting.Issues.PullRequests.AzureDevOps" Version="{{ cake_issues_version }}" />
       </ItemGroup>
     </Project>
     ```
-
-    --8<-- "snippets/version-placeholder.md"
 
 The following example shows a task which will first determine the remote repository URL and
 with this information call the [AzureDevOpsPullRequests](https://cakebuild.net/api/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemAliases/){target="_blank"}

--- a/docs/input/documentation/pull-request-systems/azure-devops/examples/repository-information.md
+++ b/docs/input/documentation/pull-request-systems/azure-devops/examples/repository-information.md
@@ -10,15 +10,13 @@ For this example the JetBrains InspectCode issue provider is additionally used f
 === "Cake .NET Tool"
 
     ```csharp title="build.cake"
-    #addin "Cake.Git" // (1)!
+    #addin nuget:?package=Cake.Git&version={{ cake_git_version }}
     #addin nuget:?package=Cake.Issues&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.InspectCode&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.PullRequests&version={{ cake_issues_version }}
     #addin nuget:?package=Cake.Issues.PullRequests.AzureDevOps&version={{ cake_issues_version }}
-    #addin "Cake.AzureDevOps" // (1)!
+    #addin nuget:?package=Cake.AzureDevOps&version={{ cake_azuredevops_version }}
     ```
-
-    --8<-- "snippets/pinning.md"
 
     !!! note
         In addition to the Azure DevOps pull request system the `Cake.Issues` and `Cake.Issues.PullRequests` core addins
@@ -36,14 +34,12 @@ For this example the JetBrains InspectCode issue provider is additionally used f
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Cake.Frosting" Version="{{ cake_version }}" />
-        <PackageReference Include="Cake.Frosting.Git" Version="1.0.0" /> // (1)!
+        <PackageReference Include="Cake.Frosting.Git" Version="{{ cake_git_version }}" />
         <PackageReference Include="Cake.Frosting.Issues.InspectCode" Version="{{ cake_issues_version }}" />
         <PackageReference Include="Cake.Frosting.Issues.PullRequests.AzureDevOps" Version="{{ cake_issues_version }}" />
       </ItemGroup>
     </Project>
     ```
-
-    --8<-- "snippets/version-placeholder.md"
 
 The following example shows a task which will first determine the remote repository URL and
 source branch of the pull request and with this information call the [AzureDevOpsPullRequests](https://cakebuild.net/api/Cake.Issues.PullRequests.AzureDevOps/AzureDevOpsPullRequestSystemAliases/){target="_blank"}

--- a/docs/input/documentation/usage/recipe/using-cake-frosting-issues-recipe.md
+++ b/docs/input/documentation/usage/recipe/using-cake-frosting-issues-recipe.md
@@ -44,14 +44,12 @@ public static class Program
             .UseContext<BuildContext>()
             .InstallTool(
                 new Uri(
-                    "nuget:?package=JetBrains.ReSharper.CommandLineTools")) // (1)
+                    "nuget:?package=JetBrains.ReSharper.CommandLineTools&version={{ resharper_commandlinetool_version }}"))
             .AddAssembly(Assembly.GetAssembly(typeof(IssuesTask)))
             .Run(args);
     }
 }
 ```
-
---8<-- "snippets/pinning.md"
 
 ## Create build context
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -109,8 +109,20 @@ markdown_extensions:
 
 # Additional configuration
 extra:
+  # renovate: datasource=nuget depName=Cake.Tool versioning=loose
   cake_version: 5.0.0
+  # renovate: datasource=nuget depName=Cake.AzureDevOps versioning=loose
+  cake_azuredevops_version: 1.0.0
+  # renovate: datasource=nuget depName=Cake.DocFx versioning=loose
+  cake_docfx_version: 1.0.0
+  # renovate: datasource=nuget depName=Cake.Issues versioning=loose
   cake_issues_version: 5.0.1
+  # renovate: datasource=nuget depName=Cake.Markdownlint versioning=loose
+  cake_markdownlint_version: 1.0.0
+  # renovate: datasource=nuget depName=Cake.Git versioning=loose
+  cake_git_version: 1.0.0
+  # renovate: datasource=nuget depName=JetBrains.ReSharper.CommandLineTools versioning=loose
+  resharper_commandlinetool_version: 1.0.0
   example_tfm: net9.0
   version:
     provider: mike

--- a/docs/snippets/pinning.md
+++ b/docs/snippets/pinning.md
@@ -1,4 +1,0 @@
-1.  In production code this dependency should be pinned to a specific version to make sure builds are deterministic and
-    won't break due to updates.
-
-    See [Reproducible Builds](https://cakebuild.net/docs/writing-builds/reproducible-builds/){target="_blank"} for details.

--- a/docs/snippets/version-placeholder.md
+++ b/docs/snippets/version-placeholder.md
@@ -1,1 +1,0 @@
-1.  Replace `1.0.0` with the desired version.


### PR DESCRIPTION
Update examples to use latest version of NuGet packages. Version is taken from configuration and updated through Renovate.