### PR TITLE
Fix example for MarkdownlintIssues alias

### DIFF
--- a/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.IssueProvider.cs
+++ b/src/Cake.Issues.Markdownlint/MarkdownlintIssuesAliases.IssueProvider.cs
@@ -112,7 +112,7 @@ public static partial class MarkdownlintIssuesAliases
     ///
     ///     var issues =
     ///         ReadIssues(
-    ///             MarkdownlintIssuesFromFilePath(settings),
+    ///             MarkdownlintIssues(settings),
     ///             @"c:\repo");
     /// ]]>
     /// </code>


### PR DESCRIPTION
Fixes example for `MarkdownlintIssues` alias