### PR TITLE
Fix RuleId on issue provider feature pages

### DIFF
--- a/docs/input/documentation/issue-providers/docfx/features.md
+++ b/docs/input/documentation/issue-providers/docfx/features.md
@@ -36,7 +36,7 @@ provides the following features.
 - [ ] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl`
 
 </div>

--- a/docs/input/documentation/issue-providers/eslint/features.md
+++ b/docs/input/documentation/issue-providers/eslint/features.md
@@ -44,7 +44,7 @@ The [Cake.Issues.EsLint addin](https://cakebuild.net/extensions/cake-issues-esli
 - [ ] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl` (4)
 
 </div>

--- a/docs/input/documentation/issue-providers/gitrepository/features.md
+++ b/docs/input/documentation/issue-providers/gitrepository/features.md
@@ -33,7 +33,7 @@ provides the following features.
 - [x] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl`
 
 </div>

--- a/docs/input/documentation/issue-providers/inspectcode/features.md
+++ b/docs/input/documentation/issue-providers/inspectcode/features.md
@@ -35,7 +35,7 @@ The [Cake.Issues.InspectCode addin]{target="_blank"} provides the following feat
 - [ ] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl`
 
 </div>

--- a/docs/input/documentation/issue-providers/markdownlint/features.md
+++ b/docs/input/documentation/issue-providers/markdownlint/features.md
@@ -51,7 +51,7 @@ provides the following features.
 - [ ] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority` (5)
 - [x] `IIssue.PriorityName` (6)
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl` (7)
 
 </div>

--- a/docs/input/documentation/issue-providers/msbuild/features.md
+++ b/docs/input/documentation/issue-providers/msbuild/features.md
@@ -42,7 +42,7 @@ provides the following features.
 - [ ] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl` (5)
 
 </div>

--- a/docs/input/documentation/issue-providers/sarif/features.md
+++ b/docs/input/documentation/issue-providers/sarif/features.md
@@ -31,7 +31,7 @@ The [Cake.Issues.Sarif addin](https://cakebuild.net/extensions/cake-issues-sarif
 - [x] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl`
 
 </div>

--- a/docs/input/documentation/issue-providers/terraform/features.md
+++ b/docs/input/documentation/issue-providers/terraform/features.md
@@ -35,7 +35,7 @@ The [Cake.Issues.Terraform addin]{target="_blank"} provides the following featur
 - [ ] `IIssue.MessageMarkdown`
 - [x] `IIssue.Priority`
 - [x] `IIssue.PriorityName`
-- [x] `IIssue.Rule`
+- [x] `IIssue.RuleId`
 - [x] `IIssue.RuleUrl`
 
 </div>


### PR DESCRIPTION
Switch from `Rule` to `RuleId` on issue provider feature pages which has changed with Cake Issues 2.0