### PR TITLE
Improve regular expression for nuspec dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,7 @@
       "fileMatch": ["\\.nuspec$"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "<dependency\\s+id=\"(?<depName>.*?)\"\\s+version=\"(?<currentValue>.*?)\"\\s*\\/>"
+        "<dependency\\s+[^>]*?id=\\\"(?<depName>.*?)\\\"\\s+[^>]*?version=\\\"(?<currentValue>.*?)\\\"[^>]*\\/?>"
       ],
       "datasourceTemplate": "nuget",
       "versioningTemplate": "nuget"


### PR DESCRIPTION
Improve regular expression for nuspec dependency updates to also handle dependencies which contain more than id and version property in this order.