### PR TITLE
Add dependency groups to .NET Tool NuGet packages

### DIFF
--- a/nuspec/nuget/Cake.Issues.DocFx.nuspec
+++ b/nuspec/nuget/Cake.Issues.DocFx.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.DocFx.
     <tags>cake cake-addin cake-issues cake-issueprovider linting docfx</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.EsLint.nuspec
+++ b/nuspec/nuget/Cake.Issues.EsLint.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.EsLint.
     <tags>cake cake-addin cake-issues cake-issueprovider code-analysis javascript linting eslint</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.GitRepository.nuspec
+++ b/nuspec/nuget/Cake.Issues.GitRepository.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.GitRepository.
     <tags>cake cake-addin cake-issues cake-issueprovider code-analysis linting git</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.InspectCode.nuspec
+++ b/nuspec/nuget/Cake.Issues.InspectCode.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.InspectCode.
     <tags>cake cake-addin cake-issues cake-issueprovider codeanalysis linting inspectcode</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Markdownlint.nuspec
+++ b/nuspec/nuget/Cake.Issues.Markdownlint.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Markdownlint.
     <tags>cake cake-addin cake-issues cake-issueprovider linting markdown markdownlint</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.MsBuild.nuspec
+++ b/nuspec/nuget/Cake.Issues.MsBuild.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.MsBuild.
     <tags>cake cake-addin cake-issues cake-issueprovider code-analysis linting msbuild</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.PullRequests.AppVeyor.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.AppVeyor.nuspec
@@ -28,6 +28,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.Ap
     <tags>cake cake-addin cake-issues cake-pullrequestsystem issues pullrequest buildserver appveyor</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.PullRequests.AzureDevOps.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.AzureDevOps.nuspec
@@ -29,6 +29,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.Az
     <tags>cake cake-addin cake-issues cake-pullrequestsystem issues pullrequest tfs azure-devops azure-devops-server</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.PullRequests.GitHubActions.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.GitHubActions.nuspec
@@ -28,6 +28,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.Gi
     <tags>cake cake-addin cake-issues cake-pullrequestsystem issues pullrequest buildserver github github-actions</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.PullRequests.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.nuspec
@@ -28,6 +28,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.PullRequests.
     <tags>Cake Script Cake-Issues CodeAnalysis Linting Issues Pull-Requests</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Reporting.Console.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Console.nuspec
@@ -30,6 +30,12 @@ The addin requires Cake 1.2.0 or higher.
     <tags>cake cake-addin cake-issues cake-reportformat issues reporting console</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Generic.nuspec
@@ -28,6 +28,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.Gener
     <tags>cake cake-addin cake-issues cake-reportformat issues reporting html markdown razor</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Reporting.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.Sarif.nuspec
@@ -28,6 +28,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.Sarif
     <tags>cake cake-addin cake-issues cake-reportformat issues reporting sarif</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Reporting.nuspec
+++ b/nuspec/nuget/Cake.Issues.Reporting.nuspec
@@ -28,6 +28,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Reporting.
     <tags>Cake Script Cake-Issues CodeAnalysis Linting Issues Reporting</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Sarif.nuspec
+++ b/nuspec/nuget/Cake.Issues.Sarif.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Sarif.
     <tags>cake cake-addin cake-issues cake-issueprovider linting sarif</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Tap.nuspec
+++ b/nuspec/nuget/Cake.Issues.Tap.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Tap.
     <tags>cake cake-addin cake-issues cake-issueprovider linting tap</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Terraform.nuspec
+++ b/nuspec/nuget/Cake.Issues.Terraform.nuspec
@@ -30,6 +30,12 @@ For addin compatible with Cake Frosting see Cake.Frosting.Issues.Terraform.
     <tags>cake cake-addin cake-issues cake-issueprovider linting terraform</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/4.9.0</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.Testing.nuspec
+++ b/nuspec/nuget/Cake.Issues.Testing.nuspec
@@ -19,6 +19,12 @@ Common helpers for testing add-ins based on Cake.Issues
     <tags>Cake Script Cake-Issues Issues Testing</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/4.5.0</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/nuspec/nuget/Cake.Issues.nuspec
+++ b/nuspec/nuget/Cake.Issues.nuspec
@@ -26,6 +26,12 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
     <tags>cake cake-addin cake-issues code-analysis linting issues</tags>
     <readme>docs\README.md</readme>
     <releaseNotes>https://github.com/cake-contrib/Cake.Issues/releases/tag/5.1.1</releaseNotes>
+    <dependencies>
+      <group targetFramework="net8.0">
+      </group>
+      <group targetFramework="net9.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\Cake.Issues.targets" target="build" />


### PR DESCRIPTION
Add dependency groups to .NET Tool NuGet packages to signalize compatible TFM

Fixes [NU5128](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128)