### PR TITLE
Try to sanitize invalid YAML containing unescaped double quotes

### DIFF
--- a/src/Cake.Issues.Tap.Tests/LogFileFormat/StylelintLogFileFormatTests.cs
+++ b/src/Cake.Issues.Tap.Tests/LogFileFormat/StylelintLogFileFormatTests.cs
@@ -129,5 +129,30 @@ public sealed class StylelintLogFileFormatTests
                     .OfRule("unknown")
                     .Create());
         }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_When_Message_Contains_Double_Quotes()
+        {
+            // Given
+            var fixture = new TapIssuesProviderFixture<StylelintLogFileFormat>("double-quotes-in-message.tap");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+
+            var issue = issues[0];
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Unexpected \"width\" property. Use \"inline-size\". (csstools/use-logical)",
+                    "Cake.Issues.Tap.TapIssuesProvider",
+                    "TAP")
+                    .InFile("path/to/file.css", 13, 13, 3, 15)
+                    .WithPriority(IssuePriority.Error)
+                    .OfRule("csstools/use-logical")
+                    .Create());
+        }
     }
 }

--- a/src/Cake.Issues.Tap.Tests/Testfiles/StylelintLogFileFormat/double-quotes-in-message.tap
+++ b/src/Cake.Issues.Tap.Tests/Testfiles/StylelintLogFileFormat/double-quotes-in-message.tap
@@ -1,0 +1,12 @@
+﻿TAP version 14
+1..1
+not ok 1 - path/to/file.css
+  ---
+  csstools/use-logical:
+    - message: "Unexpected "width" property. Use "inline-size". (csstools/use-logical)"
+      severity: error
+      line: 13
+      column: 3
+      endLine: 13
+      endColumn: 15
+  ...


### PR DESCRIPTION
Tries to sanitize and retry YAML deserialization if it fails the first time. Currently handles cases where double quotes are not escaped.

Fixes #969  