### PR TITLE
Update GitRepositoryProvider rule URL to new website

### DIFF
--- a/src/Cake.Issues.GitRepository.Tests/IssueBuilderExtensionsTests.cs
+++ b/src/Cake.Issues.GitRepository.Tests/IssueBuilderExtensionsTests.cs
@@ -10,9 +10,10 @@ public sealed class IssueBuilderExtensionsTests
             // Given
             IssueBuilder issueBuilder = null;
             var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
+            var issueProviderVersion = "1.0.0";
 
             // When
-            var result = Record.Exception(() => issueBuilder.OfRule(ruleDescription));
+            var result = Record.Exception(() => issueBuilder.OfRule(ruleDescription, issueProviderVersion));
 
             // Then
             result.IsArgumentNullException("issueBuilder");
@@ -23,13 +24,31 @@ public sealed class IssueBuilderExtensionsTests
         {
             // Given
             var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var issueProviderVersion = "1.0.0";
             BaseGitRepositoryIssuesRuleDescription ruleDescription = null;
 
             // When
-            var result = Record.Exception(() => issueBuilder.OfRule(ruleDescription));
+            var result = Record.Exception(() => issueBuilder.OfRule(ruleDescription, issueProviderVersion));
 
             // Then
             result.IsArgumentNullException("ruleDescription");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_Use_Latest_If_IssueProviderVersion_Is_Not_Set(string issueProviderVersion)
+        {
+            // Given
+            var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
+
+            // When
+            var result = issueBuilder.OfRule(ruleDescription, issueProviderVersion);
+
+            // Then
+            result.Create().RuleUrl.ToString().ShouldBe("https://cakeissues.net/latest/documentation/issue-providers/gitrepository/rules/BinaryFileNotTrackedByLfs");
         }
 
         [Fact]
@@ -37,10 +56,11 @@ public sealed class IssueBuilderExtensionsTests
         {
             // Given
             var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var issueProviderVersion = "1.0.0";
             var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
 
             // When
-            var result = issueBuilder.OfRule(ruleDescription);
+            var result = issueBuilder.OfRule(ruleDescription, issueProviderVersion);
 
             // Then
             result.Create().RuleId.ShouldBe(ruleDescription.RuleId);
@@ -51,10 +71,11 @@ public sealed class IssueBuilderExtensionsTests
         {
             // Given
             var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var issueProviderVersion = "1.0.0";
             var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
 
             // When
-            var result = issueBuilder.OfRule(ruleDescription);
+            var result = issueBuilder.OfRule(ruleDescription, issueProviderVersion);
 
             // Then
             result.Create().RuleName.ShouldBe(ruleDescription.RuleName);
@@ -65,13 +86,14 @@ public sealed class IssueBuilderExtensionsTests
         {
             // Given
             var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var issueProviderVersion = "1.0.0";
             var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
 
             // When
-            var result = issueBuilder.OfRule(ruleDescription);
+            var result = issueBuilder.OfRule(ruleDescription, issueProviderVersion);
 
             // Then
-            result.Create().RuleUrl.ToString().ShouldBe("https://cakeissues.net/docs/issue-providers/gitrepository/rules/BinaryFileNotTrackedByLfs");
+            result.Create().RuleUrl.ToString().ShouldBe("https://cakeissues.net/1.0.0/documentation/issue-providers/gitrepository/rules/BinaryFileNotTrackedByLfs");
         }
 
         [Fact]
@@ -79,10 +101,11 @@ public sealed class IssueBuilderExtensionsTests
         {
             // Given
             var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var issueProviderVersion = "1.0.0";
             var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
 
             // When
-            var result = issueBuilder.OfRule(ruleDescription);
+            var result = issueBuilder.OfRule(ruleDescription, issueProviderVersion);
 
             // Then
             result.Create().Priority.ShouldBe((int)ruleDescription.Priority);
@@ -93,10 +116,11 @@ public sealed class IssueBuilderExtensionsTests
         {
             // Given
             var issueBuilder = IssueBuilder.NewIssue("message", "providerType", "providerName");
+            var issueProviderVersion = "1.0.0";
             var ruleDescription = new BinaryFileNotTrackedByLfsRuleDescription();
 
             // When
-            var result = issueBuilder.OfRule(ruleDescription);
+            var result = issueBuilder.OfRule(ruleDescription, issueProviderVersion);
 
             // Then
             result.Create().PriorityName.ShouldBe(ruleDescription.Priority.ToString());

--- a/src/Cake.Issues.GitRepository/IssueBuilderExtensions.cs
+++ b/src/Cake.Issues.GitRepository/IssueBuilderExtensions.cs
@@ -12,18 +12,27 @@ internal static class IssueBuilderExtensions
     /// </summary>
     /// <param name="issueBuilder">Issue builder on which the properties should be set.</param>
     /// <param name="ruleDescription">Rule metadata.</param>
+    /// <param name="issueProviderVersion">Version of the issue provider.</param>
     /// <returns>Issue Builder instance.</returns>
-    public static IssueBuilder OfRule(this IssueBuilder issueBuilder, BaseGitRepositoryIssuesRuleDescription ruleDescription)
+    public static IssueBuilder OfRule(
+        this IssueBuilder issueBuilder,
+        BaseGitRepositoryIssuesRuleDescription ruleDescription,
+        string issueProviderVersion)
     {
         issueBuilder.NotNull();
         ruleDescription.NotNull();
+
+        if (string.IsNullOrWhiteSpace(issueProviderVersion))
+        {
+            issueProviderVersion = "latest";
+        }
 
         return
             issueBuilder
                 .OfRule(
                     ruleDescription.RuleId,
                     ruleDescription.RuleName,
-                    new Uri($"https://cakeissues.net/docs/issue-providers/gitrepository/rules/{ruleDescription.RuleId}"))
+                    new Uri($"https://cakeissues.net/{issueProviderVersion}/documentation/issue-providers/gitrepository/rules/{ruleDescription.RuleId}"))
                 .WithPriority(ruleDescription.Priority);
     }
 }


### PR DESCRIPTION
Update GitRepositoryProvider rule URL for new website.

Also links to documentation for specific version.