### PR TITLE
Add test cases for SARIF files created by jscpd

### DIFF
--- a/docs/input/documentation/assets/tables/supported-tools-copypaste.csv
+++ b/docs/input/documentation/assets/tables/supported-tools-copypaste.csv
@@ -1,3 +1,3 @@
 "Tool","Tool Version","Format","Issue Provider","Supported Since"
 "~~[dupFinder](https://www.jetbrains.com/help/resharper/2021.2/dupFinder.html){target='_blank'}~~{ title='Deprecated since dupFinder Command Line Tool has been sunsetted' } ",,,"Cake.Issues.DupFinder",0.8.0
-"[jscpd](https://github.com/kucherenko/jscpd){target='_blank'}",,"[jscpd-sarif-reporter](https://www.npmjs.com/package/jscpd-sarif-reporter){target='_blank'}","[Cake.Issues.Sarif](issue-providers/sarif/index.md)",4.2.0
+"[jscpd](https://github.com/kucherenko/jscpd){target='_blank'}",,"[jscpd-sarif-reporter](https://www.npmjs.com/package/jscpd-sarif-reporter){target='_blank'}","[Cake.Issues.Sarif](issue-providers/sarif/index.md)",5.4.0

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
@@ -477,5 +477,59 @@ public sealed class SarifIssuesProviderTests
             // Then
             issues.Count.ShouldBe(1106);
         }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_For_File_Generated_By_jscpd_On_Windows()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("jscpd-windows.sarif");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+
+            var issue = issues[0];
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Clone detected in tsx, - C:/Source/Cake.Issues/foo.tsx[55:26 - 70:2] and C:/Source/Cake.Issues/bar.tsx[35:27 - 51:9]",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "jscpd")
+                    .InFile(@"foo.tsx", 55, 70, 26, 2)
+                    .OfRule(
+                        "duplication",
+                        new Uri("https://github.com/kucherenko/jscpd/"))
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_For_File_Generated_By_jscpd_On_Linux()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("jscpd-linux.sarif", "/source/cake.issues");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+
+            var issue = issues[0];
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Clone detected in tsx, - /source/cake.issues/foo.tsx[55:26 - 70:2] and /source/cake.issues/bar.tsx[35:27 - 51:9]",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "jscpd")
+                    .InFile(@"foo.tsx", 55, 70, 26, 2)
+                    .OfRule(
+                        "duplication",
+                        new Uri("https://github.com/kucherenko/jscpd/"))
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
     }
 }

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/jscpd-linux.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/jscpd-linux.sarif
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "jscpd",
+                    "rules": [
+                        {
+                            "id": "duplication",
+                            "shortDescription": {
+                                "text": "Found code duplication"
+                            },
+                            "helpUri": "https://github.com/kucherenko/jscpd/"
+                        },
+                        {
+                            "id": "duplications-threshold",
+                            "shortDescription": {
+                                "text": "Level of duplication is too high"
+                            },
+                            "helpUri": "https://github.com/kucherenko/jscpd/"
+                        }
+                    ],
+                    "version": "4.0.3",
+                    "informationUri": "https://github.com/kucherenko/jscpd/"
+                }
+            },
+            "results": [
+                {
+                    "level": "warning",
+                    "message": {
+                        "text": "Clone detected in tsx, - /source/cake.issues/foo.tsx[55:26 - 70:2] and /source/cake.issues/bar.tsx[35:27 - 51:9]"
+                    },
+                    "ruleId": "duplication",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "/source/cake.issues/foo.tsx",
+                                    "index": 0
+                                },
+                                "region": {
+                                    "startLine": 55,
+                                    "startColumn": 26,
+                                    "endLine": 70,
+                                    "endColumn": 2
+                                }
+                            }
+                        }
+                    ],
+                    "ruleIndex": 0
+                }
+           ],
+            "artifacts": [
+                {
+                    "sourceLanguage": "XML",
+                    "location": {
+                        "uri": "/source/cake.issues/foo.tsx"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/jscpd-windows.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/jscpd-windows.sarif
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "jscpd",
+                    "rules": [
+                        {
+                            "id": "duplication",
+                            "shortDescription": {
+                                "text": "Found code duplication"
+                            },
+                            "helpUri": "https://github.com/kucherenko/jscpd/"
+                        },
+                        {
+                            "id": "duplications-threshold",
+                            "shortDescription": {
+                                "text": "Level of duplication is too high"
+                            },
+                            "helpUri": "https://github.com/kucherenko/jscpd/"
+                        }
+                    ],
+                    "version": "4.0.3",
+                    "informationUri": "https://github.com/kucherenko/jscpd/"
+                }
+            },
+            "results": [
+                {
+                    "level": "warning",
+                    "message": {
+                        "text": "Clone detected in tsx, - C:/Source/Cake.Issues/foo.tsx[55:26 - 70:2] and C:/Source/Cake.Issues/bar.tsx[35:27 - 51:9]"
+                    },
+                    "ruleId": "duplication",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "C:/Source/Cake.Issues/foo.tsx",
+                                    "index": 0
+                                },
+                                "region": {
+                                    "startLine": 55,
+                                    "startColumn": 26,
+                                    "endLine": 70,
+                                    "endColumn": 2
+                                }
+                            }
+                        }
+                    ],
+                    "ruleIndex": 0
+                }
+           ],
+            "artifacts": [
+                {
+                    "sourceLanguage": "XML",
+                    "location": {
+                        "uri": "C:/Source/Cake.Issues/foo.tsx"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Add test case for files generated by jscpd. 

Also updates required version of Cake.Issues.Sarif for jscpd to 5.4.0, since previously absolute paths were not supported.