### PR TITLE
Support absolute paths in SARIF files

### DIFF
--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderFixture.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderFixture.cs
@@ -1,8 +1,20 @@
 ﻿namespace Cake.Issues.Sarif.Tests;
 
-internal class SarifIssuesProviderFixture(string fileResourceName)
-    : BaseConfigurableIssueProviderFixture<SarifIssuesProvider, SarifIssuesSettings>(fileResourceName)
+internal class SarifIssuesProviderFixture
+    : BaseConfigurableIssueProviderFixture<SarifIssuesProvider, SarifIssuesSettings>
 {
+    public SarifIssuesProviderFixture(string fileResourceName)
+        : this(fileResourceName, @"c:\Source\Cake.Issues")
+    {
+    }
+
+    public SarifIssuesProviderFixture(string fileResourceName, string repositoryRoot)
+        : base(fileResourceName)
+    {
+        this.ReadIssuesSettings =
+            new ReadIssuesSettings(repositoryRoot);
+    }
+
     public bool UseToolNameAsIssueProviderName { get; set; } = true;
 
     public bool IgnoreSuppressedIssues { get; set; } = true;

--- a/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
+++ b/src/Cake.Issues.Sarif.Tests/SarifIssuesProviderTests.cs
@@ -122,6 +122,126 @@ public sealed class SarifIssuesProviderTests
         }
 
         [Fact]
+        public void Should_Read_Issue_Correct_For_File_With_Absolute_Path_Not_Conform_To_RFC3986_Generated_On_Linux()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("absolute-path-linux-non-rfc3986.sarif", "/src/cake.issues");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+            var issue = issues.Single();
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Variable \"count\" was used without being initialized.",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "CodeScanner")
+                    .InFile(@"collections\list.cpp", 15)
+                    .OfRule("C2001")
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_For_File_With_Absolute_Path_Conform_To_RFC3986_Generated_On_Linux()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("absolute-path-linux-rfc3986.sarif", "/src/cake.issues");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+            var issue = issues.Single();
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Variable \"count\" was used without being initialized.",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "CodeScanner")
+                    .InFile(@"collections\list.cpp", 15)
+                    .OfRule("C2001")
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_For_File_With_Absolute_Path_Not_Conform_To_RFC3986_Generated_On_Windows()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("absolute-path-windows-non-rfc3986.sarif");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+            var issue = issues.Single();
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Variable \"count\" was used without being initialized.",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "CodeScanner")
+                    .InFile(@"collections\list.cpp", 15)
+                    .OfRule("C2001")
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_For_File_With_Absolute_Path_Conform_To_RFC3986_Generated_On_Windows()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("absolute-path-windows-rfc3986.sarif");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+            var issue = issues.Single();
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Variable \"count\" was used without being initialized.",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "CodeScanner")
+                    .InFile(@"collections\list.cpp", 15)
+                    .OfRule("C2001")
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_For_File_With_Relative_Path()
+        {
+            // Given
+            var fixture = new SarifIssuesProviderFixture("relative-path.sarif");
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(1);
+            var issue = issues.Single();
+            IssueChecker.Check(
+                issue,
+                IssueBuilder.NewIssue(
+                    "Variable \"count\" was used without being initialized.",
+                    "Cake.Issues.Sarif.SarifIssuesProvider",
+                    "CodeScanner")
+                    .InFile(@"src\collections\list.cpp", 15)
+                    .OfRule("C2001")
+                    .WithPriority(IssuePriority.Warning)
+                    .Create());
+        }
+
+        [Fact]
         public void Should_Ignore_Suppressed_Issues_If_IgnoreSuppressedIssues_Is_Enabled()
         {
             // Given

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-linux-non-rfc3986.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-linux-non-rfc3986.sarif
@@ -1,0 +1,56 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "rules": [
+            {
+              "id": "C2001",
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result
+
+                        in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "message": {
+            "id": "default",
+            "arguments": [
+              "count"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "/src/cake.issues/collections/list.cpp"
+                },
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-linux-rfc3986.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-linux-rfc3986.sarif
@@ -1,0 +1,56 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "rules": [
+            {
+              "id": "C2001",
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result
+
+                        in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "message": {
+            "id": "default",
+            "arguments": [
+              "count"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://src/cake.issues/collections/list.cpp"
+                },
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-windows-non-rfc3986.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-windows-non-rfc3986.sarif
@@ -1,0 +1,56 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "rules": [
+            {
+              "id": "C2001",
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result
+
+                        in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "message": {
+            "id": "default",
+            "arguments": [
+              "count"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "C:/Source/Cake.Issues/collections/list.cpp"
+                },
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-windows-rfc3986.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/absolute-path-windows-rfc3986.sarif
@@ -1,0 +1,56 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "rules": [
+            {
+              "id": "C2001",
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result
+
+                        in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "message": {
+            "id": "default",
+            "arguments": [
+              "count"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file://C:/Source/Cake.Issues/collections/list.cpp"
+                },
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Cake.Issues.Sarif.Tests/Testfiles/relative-path.sarif
+++ b/src/Cake.Issues.Sarif.Tests/Testfiles/relative-path.sarif
@@ -1,0 +1,67 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "rules": [
+            {
+              "id": "C2001",
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result
+
+                        in runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized."
+                }
+              }
+            }
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "src/collections/list.cpp",
+            "uriBaseId": "SRCROOT"
+          },
+          "sourceLanguage": "c"
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "message": {
+            "id": "default",
+            "arguments": [
+              "count"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/collections/list.cpp",
+                  "uriBaseId": "SRCROOT",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 15
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Support absolute paths, either RFC 3986 conform or non-conform, in SARIF files

Fixes #1010 