### PR TITLE
HtmlDxDataGrid: Use 100% of page height

### DIFF
--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-additionalcolumns.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-additionalcolumns.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-changetitle.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-changetitle.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>My Custom Title</h1>
-
     <div class="container">
+            <h1>My Custom Title</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-columnhiding.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-columnhiding.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-customexportfilename.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-customexportfilename.html
@@ -17,6 +17,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -37,9 +51,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-customscriptlocation.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-customscriptlocation.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/18.2.3/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-default.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-default.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disablefiltering.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disablefiltering.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disablegrouping.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disablegrouping.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disableheader.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disableheader.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,7 +49,6 @@
     </style>
 </head>
 <body class="dx-viewport">
-
     <div class="container">
         <div id="gridContainer"></div>
     </div>

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disablesearching.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-disablesearching.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-enableexporting.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-enableexporting.html
@@ -17,6 +17,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -37,9 +51,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-exportformat-pdf.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-exportformat-pdf.html
@@ -17,6 +17,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -37,9 +51,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-exportformat-xlsx.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-exportformat-xlsx.html
@@ -17,6 +17,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -37,9 +51,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-grouping.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-grouping.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-sorting.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-sorting.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-carmine.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-carmine.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-contrast.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-contrast.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-contrastcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-contrastcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-dark.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-dark.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-darkcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-darkcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-darkmoon.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-darkmoon.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-darkviolet.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-darkviolet.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-greenmist.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-greenmist.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-light.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-light.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-lightcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-lightcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluedark.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluedark.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluedarkcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluedarkcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluelight.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluelight.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluelightcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialbluelightcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimedark.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimedark.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimedarkcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimedarkcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimelight.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimelight.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimelightcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materiallimelightcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangedark.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangedark.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangedarkcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangedarkcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangelight.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangelight.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangelightcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialorangelightcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurpledark.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurpledark.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurpledarkcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurpledarkcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurplelight.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurplelight.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurplelightcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialpurplelightcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialtealdark.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialtealdark.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialtealdarkcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialtealdarkcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialteallight.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialteallight.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialteallightcompact.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-materialteallightcompact.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-softblue.html
+++ b/docs/input/documentation/report-formats/generic/templates/htmldxdatagrid-demo-theme-softblue.html
@@ -15,6 +15,20 @@
     <script type="text/javascript" src="https://cdn3.devexpress.com/jslib/23.1.11/js/dx.all.js"></script>
 
     <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         .dx-theme-material-typography h1
         {
             font-weight: 200;
@@ -35,9 +49,8 @@
     </style>
 </head>
 <body class="dx-viewport">
-        <h1>Issues Report</h1>
-
     <div class="container">
+            <h1>Issues Report</h1>
         <div id="gridContainer"></div>
     </div>
 

--- a/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
+++ b/src/Cake.Issues.Reporting.Generic/Templates/DxDataGrid.cshtml
@@ -146,6 +146,21 @@
     }
 
     <style>
+        @* Set grid to use 100% of height *@
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+        #gridContainer {
+            flex: 1;
+            overflow: auto;
+        }
         @* Reduce title size for material themes *@
         .dx-theme-material-typography h1
         {
@@ -169,12 +184,11 @@
     </style>
 </head>
 <body class="dx-viewport">
-    @if (showHeader)
-    {
-        <h1>@title</h1>
-    }
-
     <div class="container">
+        @if (showHeader)
+        {
+            <h1>@title</h1>
+        }
         <div id="gridContainer"></div>
     </div>
 


### PR DESCRIPTION
Render grid to use 100% of height to ensure pager is always visible. If there are more records shown than fit on the page the grid will provide scrolling