### PR TITLE
Checkout LFS files for building website

### DIFF
--- a/.github/workflows/publish-develop-docs.yml
+++ b/.github/workflows/publish-develop-docs.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Get the sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          lfs: true
           fetch-depth: 0
       - name: Install Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5

--- a/.github/workflows/publish-release-docs.yml
+++ b/.github/workflows/publish-release-docs.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Get the sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          lfs: true
           fetch-depth: 0
       - name: Install Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5


### PR DESCRIPTION
Checkout LFS files for building website, which is required to have images available, since they are now tracked by LFS