### PR TITLE
Use meta plugin to configure search for news entries

### DIFF
--- a/docs/input/news/posts/.meta.yml
+++ b/docs/input/news/posts/.meta.yml
@@ -1,0 +1,2 @@
+search:
+  boost: 0.5

--- a/docs/input/news/posts/2020-08-22-cake-issues-v0.9.0-released.md
+++ b/docs/input/news/posts/2020-08-22-cake-issues-v0.9.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v0.9.0 Released
 date: 2020-08-22
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/usage/reading-issues/file-linking.md
 ---

--- a/docs/input/news/posts/2020-09-19-cake-issues-v0.9.1-released.md
+++ b/docs/input/news/posts/2020-09-19-cake-issues-v0.9.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v0.9.1 Released
 date: 2020-09-19
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/usage/reading-issues/file-linking.md
   - documentation/pull-request-systems/azure-devops/index.md

--- a/docs/input/news/posts/2020-09-24-cake-issues-recipe-v0.4.2-released.md
+++ b/docs/input/news/posts/2020-09-24-cake-issues-recipe-v0.4.2-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Recipe v0.4.2 released, bringing support for GitHub Actions
 date: 2020-09-24
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Version 0.4.2 of Cake Issues Recipe has been released bringing support for GitHub Actions.

--- a/docs/input/news/posts/2020-09-27-github-actions-addin.md
+++ b/docs/input/news/posts/2020-09-27-github-actions-addin.md
@@ -3,8 +3,6 @@ title: New GitHub Actions addin
 date: 2020-09-27
 categories:
   - New Addin
-search:
-  boost: 0.5
 links:
   - documentation/pull-request-systems/github-actions/index.md
 ---

--- a/docs/input/news/posts/2020-10-09-cake-issues-pullrequests-v0.9.1-released.md
+++ b/docs/input/news/posts/2020-10-09-cake-issues-pullrequests-v0.9.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues PullRequests v0.9.1 Released
 date: 2020-10-09
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Version 0.9.1 of Cake.Issues.PullRequests has been released.

--- a/docs/input/news/posts/2020-10-20-cake-issues-msbuild-v0.9.1-released.md
+++ b/docs/input/news/posts/2020-10-20-cake-issues-msbuild-v0.9.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues MsBuild v0.9.1 Released
 date: 2020-10-20
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
 ---

--- a/docs/input/news/posts/2020-12-01-cake-issues-recipe-v0.4.4-released.md
+++ b/docs/input/news/posts/2020-12-01-cake-issues-recipe-v0.4.4-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Recipe v0.4.4 released, bringing support for ESLint
 date: 2020-12-01
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Version 0.4.4 of Cake Issues Recipe has been released bringing support for ESLint.

--- a/docs/input/news/posts/2021-07-27-terraform-addin.md
+++ b/docs/input/news/posts/2021-07-27-terraform-addin.md
@@ -3,8 +3,6 @@ title: New addin for Terraform support
 date: 2021-07-27
 categories:
   - New Addin
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/terraform/index.md
 ---

--- a/docs/input/news/posts/2021-07-28-cake-issues-v1.0.0-released.md
+++ b/docs/input/news/posts/2021-07-28-cake-issues-v1.0.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v1.0.0 Released
 date: 2021-07-28
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - Cake v1.0.0 released: https://cakebuild.net/blog/2021/02/cake-v1.0.0-released
 ---

--- a/docs/input/news/posts/2021-07-30-cake-issues-eslint-v1.0.1-released.md
+++ b/docs/input/news/posts/2021-07-30-cake-issues-eslint-v1.0.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues ESLint v1.0.1 Released
 date: 2021-07-30
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/eslint/index.md
 ---

--- a/docs/input/news/posts/2021-08-04-cake-issues-recipe-v1.0.0-released.md
+++ b/docs/input/news/posts/2021-08-04-cake-issues-recipe-v1.0.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Recipe v1.0.0 Released, bringing support for Cake Frosting
 date: 2021-08-04 
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Hard on the heels of the [announcement for release 1.0 of Cake.Issues addins],

--- a/docs/input/news/posts/2021-08-11-cake-issues-recipe-v1.1.0-released.md
+++ b/docs/input/news/posts/2021-08-11-cake-issues-recipe-v1.1.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Recipes v1.1.0 released
 date: 2021-08-11 
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Version 1.1.0 of Cake Issues recipes have been released adding support to customize report generation.

--- a/docs/input/news/posts/2021-08-19-cake-issues-recipe-v1.2.0-released.md
+++ b/docs/input/news/posts/2021-08-19-cake-issues-recipe-v1.2.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Recipes v1.2.0 released
 date: 2021-08-19 
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Version 1.2.0 of Cake Issues recipes have been released adding support to customize issue reporting to pull requests.

--- a/docs/input/news/posts/2021-08-29-console-addin.md
+++ b/docs/input/news/posts/2021-08-29-console-addin.md
@@ -3,8 +3,6 @@ title: New addin for printing issues to console
 date: 2021-08-29
 categories:
   - New Addin
-search:
-  boost: 0.5
 links:
   - documentation/report-formats/console/index.md
 ---

--- a/docs/input/news/posts/2021-08-31-cake-issues-markdownlint-v1.1.0.md
+++ b/docs/input/news/posts/2021-08-31-cake-issues-markdownlint-v1.1.0.md
@@ -3,8 +3,6 @@ title: Cake Issues Markdownlint v1.1.0 Released
 date: 2021-08-31
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/markdownlint/index.md
 ---

--- a/docs/input/news/posts/2021-09-05-cake-issues-reporting-0-3-0-released.md
+++ b/docs/input/news/posts/2021-09-05-cake-issues-reporting-0-3-0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Reporting Console v0.3.0 released, adding support for all Cak
 date: 2021-09-05
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/report-formats/console/index.md
 ---

--- a/docs/input/news/posts/2022-12-10-cake-issues-v2.0.0-released.md
+++ b/docs/input/news/posts/2022-12-10-cake-issues-v2.0.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v2.0.0 Released
 date: 2022-12-10
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - Cake v2.0.0 released: https://cakebuild.net/blog/2021/11/cake-v2.0.0-released
   - documentation/issue-providers/msbuild/index.md

--- a/docs/input/news/posts/2023-07-22-cake-issues-v3.0.0-released.md
+++ b/docs/input/news/posts/2023-07-22-cake-issues-v3.0.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v3.0.0 Released
 date: 2023-07-22
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - Cake v3.0.0 released: https://cakebuild.net/blog/2022/11/cake-v3.0.0-released
   - documentation/issue-providers/msbuild/index.md

--- a/docs/input/news/posts/2023-08-16-cake-issues-recipe-v3.1.0-released.md
+++ b/docs/input/news/posts/2023-08-16-cake-issues-recipe-v3.1.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues Recipes v3.1.0 released
 date: 2023-08-16
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Version 3.1.0 of Cake Issues recipes have been released adding support for creating of reports in SARIF format.

--- a/docs/input/news/posts/2023-12-23-cake-issues-v4.0.0-released.md
+++ b/docs/input/news/posts/2023-12-23-cake-issues-v4.0.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.0.0 Released
 date: 2023-12-23
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - Cake v4.0.0 released: https://cakebuild.net/blog/2023/11/cake-v4.0.0-released
 ---

--- a/docs/input/news/posts/2024-01-14-align-addin-lifecycle.md
+++ b/docs/input/news/posts/2024-01-14-align-addin-lifecycle.md
@@ -3,8 +3,6 @@ title: Alignment of addin lifecycles
 date: 2024-01-14
 categories:
   - Announcements
-search:
-  boost: 0.5
 ---
 
 Cake Issues has a [modular architecture] consisting of multiple addins.

--- a/docs/input/news/posts/2024-02-21-cake-issues-v4.1.0-released.md
+++ b/docs/input/news/posts/2024-02-21-cake-issues-v4.1.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.1.0 Released
 date: 2024-02-21
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
 ---

--- a/docs/input/news/posts/2024-04-14-cake-issues-v4.2.0-released.md
+++ b/docs/input/news/posts/2024-04-14-cake-issues-v4.2.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.2.0 Released
 date: 2024-04-14
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/sarif/index.md
 ---

--- a/docs/input/news/posts/2024-04-14-sarif-issue-provider.md
+++ b/docs/input/news/posts/2024-04-14-sarif-issue-provider.md
@@ -3,8 +3,6 @@ title: New addin for reading SARIF files
 date: 2024-04-14
 categories:
   - New Addin
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/sarif/index.md
 ---

--- a/docs/input/news/posts/2024-04-16-cake-issues-v4.2.1-released.md
+++ b/docs/input/news/posts/2024-04-16-cake-issues-v4.2.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.2.1 Released
 date: 2024-04-16
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Cake Issues version 4.2.1 has been released with compatibility fixes.

--- a/docs/input/news/posts/2024-04-20-cake-issues-v4.3.0-released.md
+++ b/docs/input/news/posts/2024-04-20-cake-issues-v4.3.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.3.0 Released
 date: 2024-04-20
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
 ---

--- a/docs/input/news/posts/2024-04-25-cake-issues-v4.3.1-released.md
+++ b/docs/input/news/posts/2024-04-25-cake-issues-v4.3.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.3.1 Released
 date: 2024-04-25
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Cake Issues version 4.3.1 has been released bringing bug fixes.

--- a/docs/input/news/posts/2024-05-18-cake-issues-v4.4.0-released.md
+++ b/docs/input/news/posts/2024-05-18-cake-issues-v4.4.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.4.0 Released
 date: 2024-05-18
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/report-formats/generic/templates/htmldxdatagrid.md
 ---

--- a/docs/input/news/posts/2024-05-23-cake-issues-v4.5.0-released.md
+++ b/docs/input/news/posts/2024-05-23-cake-issues-v4.5.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.5.0 Released
 date: 2024-05-23
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/usage/breaking-builds/breaking-builds.md
   - documentation/report-formats/generic/templates/htmldxdatagrid.md

--- a/docs/input/news/posts/2024-05-24-cake-issues-v4.5.1-released.md
+++ b/docs/input/news/posts/2024-05-24-cake-issues-v4.5.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.5.1 Released
 date: 2024-05-24
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Cake Issues version 4.5.1 has been released containing bug fixes.

--- a/docs/input/news/posts/2024-06-24-cake-issues-v4.6.0-released.md
+++ b/docs/input/news/posts/2024-06-24-cake-issues-v4.6.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.6.0 Released
 date: 2024-06-24
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/sarif/index.md
 ---

--- a/docs/input/news/posts/2024-07-16-cake-issues-v4.7.0-released.md
+++ b/docs/input/news/posts/2024-07-16-cake-issues-v4.7.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.7.0 Released
 date: 2024-07-16
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
   - documentation/issue-providers/sarif/index.md

--- a/docs/input/news/posts/2024-07-17-cake-issues-v4.7.1-released.md
+++ b/docs/input/news/posts/2024-07-17-cake-issues-v4.7.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.7.1 Released
 date: 2024-07-17
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/sarif/index.md
 ---

--- a/docs/input/news/posts/2024-07-18-cake-issues-v4.7.2-released.md
+++ b/docs/input/news/posts/2024-07-18-cake-issues-v4.7.2-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.7.2 Released
 date: 2024-07-18
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/report-formats/generic/templates/htmldxdatagrid.md
 ---

--- a/docs/input/news/posts/2024-07-19-cake-issues-v4.8.0-released.md
+++ b/docs/input/news/posts/2024-07-19-cake-issues-v4.8.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.8.0 Released
 date: 2024-07-19
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/sarif/index.md
 ---

--- a/docs/input/news/posts/2024-07-25-cake-issues-v4.9.0-released.md
+++ b/docs/input/news/posts/2024-07-25-cake-issues-v4.9.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.9.0 Released
 date: 2024-07-25
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/sarif/index.md
   - documentation/issue-providers/terraform/index.md

--- a/docs/input/news/posts/2024-07-30-cake-issues-v4.10.0-released.md
+++ b/docs/input/news/posts/2024-07-30-cake-issues-v4.10.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.10.0 Released
 date: 2024-07-30
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
 ---

--- a/docs/input/news/posts/2024-08-20-cake-issues-v4.10.1-released.md
+++ b/docs/input/news/posts/2024-08-20-cake-issues-v4.10.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.10.1 Released
 date: 2024-08-20
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/usage/reading-issues/file-linking.md
 ---

--- a/docs/input/news/posts/2024-10-06-cake-issues-v4.11.0-released.md
+++ b/docs/input/news/posts/2024-10-06-cake-issues-v4.11.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.11.0 Released
 date: 2024-10-06
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
 ---

--- a/docs/input/news/posts/2024-11-05-cake-issues-v4.12.0-released.md
+++ b/docs/input/news/posts/2024-11-05-cake-issues-v4.12.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v4.12.0 Released
 date: 2024-11-05
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/msbuild/index.md
 ---

--- a/docs/input/news/posts/2024-12-02-cake-issues-v5.0.0-released.md
+++ b/docs/input/news/posts/2024-12-02-cake-issues-v5.0.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.0.0 Released
 date: 2024-12-02
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - Cake v5.0.0 released: https://cakebuild.net/blog/2024/11/cake-v5.0.0-released
 ---

--- a/docs/input/news/posts/2024-12-17-cake-issues-v5.0.1-released.md
+++ b/docs/input/news/posts/2024-12-17-cake-issues-v5.0.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.0.1 Released
 date: 2024-12-17
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Cake Issues version 5.0.1 has been released containing bug fixes for Cake Frosting addins

--- a/docs/input/news/posts/2024-12-21-new-website.md
+++ b/docs/input/news/posts/2024-12-21-new-website.md
@@ -3,8 +3,6 @@ title: New website
 date: 2024-12-21
 categories:
   - Announcements
-search:
-  boost: 0.5
 links:
   - Material for MkDocs: https://squidfunk.github.io/mkdocs-material/
 ---

--- a/docs/input/news/posts/2025-01-01-2024-recap.md
+++ b/docs/input/news/posts/2025-01-01-2024-recap.md
@@ -3,8 +3,6 @@ title: 2024 In Review
 date: 2025-01-01
 categories:
   - Announcements
-search:
-  boost: 0.5
 ---
 
 2024 had been an amazing year for Cake Issues. In this post we'll look back to what had been achieved in 2024.

--- a/docs/input/news/posts/2025-01-03-cake-issues-v5.1.0-released.md
+++ b/docs/input/news/posts/2025-01-03-cake-issues-v5.1.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.1.0 Released
 date: 2025-01-03
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/tap/index.md
 ---

--- a/docs/input/news/posts/2025-01-03-tap-issue-provider.md
+++ b/docs/input/news/posts/2025-01-03-tap-issue-provider.md
@@ -3,8 +3,6 @@ title: New addin for reading Test Anything Protocol (TAP) files
 date: 2025-01-03
 categories:
   - New Addin
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/tap/index.md
 ---

--- a/docs/input/news/posts/2025-01-05-cake-issues-v5.1.1-released.md
+++ b/docs/input/news/posts/2025-01-05-cake-issues-v5.1.1-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.1.1 Released
 date: 2025-01-05
 categories:
   - Release Notes
-search:
-  boost: 0.5
 ---
 
 Cake Issues version 5.1.1 has been released containing bug fixes for Cake Frosting addins

--- a/docs/input/news/posts/2025-01-09-cake-issues-v5.2.0-released.md
+++ b/docs/input/news/posts/2025-01-09-cake-issues-v5.2.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.2.0 Released
 date: 2025-01-09
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/usage/breaking-builds/breaking-builds.md
   - documentation/issue-providers/sarif/index.md

--- a/docs/input/news/posts/2025-01-10-cake-issues-v5.3.0-released.md
+++ b/docs/input/news/posts/2025-01-10-cake-issues-v5.3.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.3.0 Released
 date: 2025-01-10
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/issue-providers/tap/index.md
 ---

--- a/docs/input/news/posts/2025-01-16-cake-issues-v5.4.0-released.md
+++ b/docs/input/news/posts/2025-01-16-cake-issues-v5.4.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.4.0 Released
 date: 2025-01-16
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/usage/breaking-builds/breaking-builds.md
   - documentation/issue-providers/sarif/index.md

--- a/docs/input/news/posts/2025-01-23-cake-issues-v5.5.0-released.md
+++ b/docs/input/news/posts/2025-01-23-cake-issues-v5.5.0-released.md
@@ -3,8 +3,6 @@ title: Cake Issues v5.5.0 Released
 date: 2025-01-23
 categories:
   - Release Notes
-search:
-  boost: 0.5
 links:
   - documentation/report-formats/generic/templates/htmldxdatagrid.md
 ---

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ plugins:
       post_readtime: true
   - glightbox
   - macros
+  - meta
   - minify:
       minify_html: true
       htmlmin_opts:


### PR DESCRIPTION
Use meta plugin to rank down all news entries instead of individual settings on every news entry