### PR TITLE
Add update about accidential deprecation of Microsoft.Identity.Client

### DIFF
--- a/docs/input/news/posts/2025-07-11-microsoft-deleted-package.md
+++ b/docs/input/news/posts/2025-07-11-microsoft-deleted-package.md
@@ -19,7 +19,7 @@ They had a typo in an XML comment inside `Microsoft.Identity.Client`.
 `Microsoft.Identity.Client` is a dependency of `Cake.AzureDevOps`, which is used by `Cake.Frosting.Issues.PullRequests.AzureDevOps`.
 
 When looking at the [release notes of Microsoft.Identity.Client 4.72.1](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/releases/tag/4.72.1) it not even mentions any CVE or related fixes.
-In contrast to what was written in the email it was also not fixed in [Microsoft.Identity.Client 4.72.1](https://www.nuget.org/packages/Microsoft.Identity.Client/4.72.1) based on the warning on nuget.org.
+In contrast to what was written in the email it was also not fixed in [Microsoft.Identity.Client 4.72.1](https://www.nuget.org/packages/Microsoft.Identity.Client/4.72.1) based on the warning on nuget.org[^1].
 
 Beside that, it is not someting which can be directly fixed in `Cake.Frosting.Issues.PullRequests.AzureDevOps`, since it is a transitive dependency through `Cake.AzureDevOps`.
 It is also not a real security issue, since no user of a build script will likely check XML comments from a transitive dependency and type them in a browser.
@@ -36,3 +36,5 @@ Please stick with 5.5.0 in these cases.
 
 There is also an excellent [blog post by Aaron Stannard](https://aaronstannard.com/microsoft-delete-nuget-packages) about this incident and
 a [GithHub issue](https://github.com/NuGet/Home/discussions/14413).
+
+[^1]: Seems like the deprecation of Microsoft.Identity.Client 4.72.1 was [another mistake](https://github.com/NuGet/Home/discussions/14413#discussioncomment-13737685), which has been reverted in the meantime.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -94,6 +94,7 @@ markdown_extensions:
   - abbr
   - admonition
   - attr_list
+  - footnotes
   - md_in_html
   - pymdownx.details
   - pymdownx.emoji:


### PR DESCRIPTION
Adds update that Microsoft.Identity.Client 4.72.1 has now been reverted again