### PR TITLE
Update to Cake.AzureDevOps 5.0.2

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -134,7 +134,7 @@ extra:
   # renovate: datasource=nuget depName=Cake.Tool versioning=loose
   cake_version: 5.0.0
   # renovate: datasource=nuget depName=Cake.AzureDevOps versioning=loose
-  cake_azuredevops_version: 5.0.0
+  cake_azuredevops_version: 5.0.2
   # renovate: datasource=nuget depName=Cake.DocFx versioning=loose
   cake_docfx_version: 1.0.0
   # renovate: datasource=nuget depName=Cake.Issues versioning=loose

--- a/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AzureDevOps.nuspec
+++ b/nuspec/nuget/Cake.Frosting.Issues.PullRequests.AzureDevOps.nuspec
@@ -32,11 +32,11 @@ For addin compatible with Cake Script Runners see Cake.Issues.PullRequests.Azure
     <dependencies>
       <group targetFramework="net8.0">
         <dependency id="Cake.Frosting.Issues.PullRequests" version="[5.0.0-beta0001,6.0)" exclude="Build,Analyzers" />
-        <dependency id="Cake.Frosting.AzureDevOps" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Frosting.AzureDevOps" version="5.0.2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net9.0">
         <dependency id="Cake.Frosting.Issues.PullRequests" version="[5.0.0-beta0001,6.0)" exclude="Build,Analyzers" />
-        <dependency id="Cake.Frosting.AzureDevOps" version="5.0.0" exclude="Build,Analyzers" />
+        <dependency id="Cake.Frosting.AzureDevOps" version="5.0.2" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Cake.Issues.PullRequests.AzureDevOps.Tests/packages.lock.json
+++ b/src/Cake.Issues.PullRequests.AzureDevOps.Tests/packages.lock.json
@@ -123,8 +123,8 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.66.2",
-        "contentHash": "OsWRWpJs5iY9DxAF7DfWRGVNeFhjz75x+/bpHKB9Hbnu3THUgqYfQrYeQMgwx30ctweiV7h00aQpEua2kLeUpg==",
+        "resolved": "4.72.1",
+        "contentHash": "U3FbgYeKbU34zP17vi4xO70U5WiVO4GcqHbGwfqzAGJMQQfzkdEK5Ue69mI1tWj7Ft2lbJJ9Wsho9/6Jn5OKqQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -1381,7 +1381,7 @@
       "cake.issues.pullrequests.azuredevops": {
         "type": "Project",
         "dependencies": {
-          "Cake.Frosting.AzureDevOps": "[5.0.0, )",
+          "Cake.Frosting.AzureDevOps": "[5.0.2, )",
           "Cake.Issues.PullRequests": "[1.0.0, )"
         }
       },
@@ -1405,12 +1405,12 @@
       },
       "Cake.Frosting.AzureDevOps": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "P0WE3e2Z1pmfIdrRG7vuWQE+29vNZzuWUprvi5inOc08pPBe0HfmOnK6Bkd4cY1yFw6tBaPStUDFjG+wQSKafQ==",
+        "requested": "[5.0.2, )",
+        "resolved": "5.0.2",
+        "contentHash": "Jlgnmh7kSgvBK4AwUjOq0NM/fBUJFcJjuvTFiosaGj7vamFWHIVc6N/efzgCu/woLXZBIBs5XnYGBDl7ZcjDcA==",
         "dependencies": {
           "Cake.Core": "5.0.0",
-          "Microsoft.Identity.Client": "4.66.2",
+          "Microsoft.Identity.Client": "4.72.1",
           "Microsoft.TeamFoundationServer.Client": "19.225.1",
           "Microsoft.VisualStudio.Services.InteractiveClient": "19.225.1",
           "System.Data.SqlClient": "4.9.0",
@@ -1577,8 +1577,8 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.66.2",
-        "contentHash": "OsWRWpJs5iY9DxAF7DfWRGVNeFhjz75x+/bpHKB9Hbnu3THUgqYfQrYeQMgwx30ctweiV7h00aQpEua2kLeUpg==",
+        "resolved": "4.72.1",
+        "contentHash": "U3FbgYeKbU34zP17vi4xO70U5WiVO4GcqHbGwfqzAGJMQQfzkdEK5Ue69mI1tWj7Ft2lbJJ9Wsho9/6Jn5OKqQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -2835,7 +2835,7 @@
       "cake.issues.pullrequests.azuredevops": {
         "type": "Project",
         "dependencies": {
-          "Cake.Frosting.AzureDevOps": "[5.0.0, )",
+          "Cake.Frosting.AzureDevOps": "[5.0.2, )",
           "Cake.Issues.PullRequests": "[1.0.0, )"
         }
       },
@@ -2859,12 +2859,12 @@
       },
       "Cake.Frosting.AzureDevOps": {
         "type": "CentralTransitive",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "P0WE3e2Z1pmfIdrRG7vuWQE+29vNZzuWUprvi5inOc08pPBe0HfmOnK6Bkd4cY1yFw6tBaPStUDFjG+wQSKafQ==",
+        "requested": "[5.0.2, )",
+        "resolved": "5.0.2",
+        "contentHash": "Jlgnmh7kSgvBK4AwUjOq0NM/fBUJFcJjuvTFiosaGj7vamFWHIVc6N/efzgCu/woLXZBIBs5XnYGBDl7ZcjDcA==",
         "dependencies": {
           "Cake.Core": "5.0.0",
-          "Microsoft.Identity.Client": "4.66.2",
+          "Microsoft.Identity.Client": "4.72.1",
           "Microsoft.TeamFoundationServer.Client": "19.225.1",
           "Microsoft.VisualStudio.Services.InteractiveClient": "19.225.1",
           "System.Data.SqlClient": "4.9.0",

--- a/src/Cake.Issues.PullRequests.AzureDevOps/packages.lock.json
+++ b/src/Cake.Issues.PullRequests.AzureDevOps/packages.lock.json
@@ -4,12 +4,12 @@
     "net8.0": {
       "Cake.Frosting.AzureDevOps": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "P0WE3e2Z1pmfIdrRG7vuWQE+29vNZzuWUprvi5inOc08pPBe0HfmOnK6Bkd4cY1yFw6tBaPStUDFjG+wQSKafQ==",
+        "requested": "[5.0.2, )",
+        "resolved": "5.0.2",
+        "contentHash": "Jlgnmh7kSgvBK4AwUjOq0NM/fBUJFcJjuvTFiosaGj7vamFWHIVc6N/efzgCu/woLXZBIBs5XnYGBDl7ZcjDcA==",
         "dependencies": {
           "Cake.Core": "5.0.0",
-          "Microsoft.Identity.Client": "4.66.2",
+          "Microsoft.Identity.Client": "4.72.1",
           "Microsoft.TeamFoundationServer.Client": "19.225.1",
           "Microsoft.VisualStudio.Services.InteractiveClient": "19.225.1",
           "System.Data.SqlClient": "4.9.0",
@@ -46,8 +46,8 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.66.2",
-        "contentHash": "OsWRWpJs5iY9DxAF7DfWRGVNeFhjz75x+/bpHKB9Hbnu3THUgqYfQrYeQMgwx30ctweiV7h00aQpEua2kLeUpg==",
+        "resolved": "4.72.1",
+        "contentHash": "U3FbgYeKbU34zP17vi4xO70U5WiVO4GcqHbGwfqzAGJMQQfzkdEK5Ue69mI1tWj7Ft2lbJJ9Wsho9/6Jn5OKqQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -1244,12 +1244,12 @@
     "net9.0": {
       "Cake.Frosting.AzureDevOps": {
         "type": "Direct",
-        "requested": "[5.0.0, )",
-        "resolved": "5.0.0",
-        "contentHash": "P0WE3e2Z1pmfIdrRG7vuWQE+29vNZzuWUprvi5inOc08pPBe0HfmOnK6Bkd4cY1yFw6tBaPStUDFjG+wQSKafQ==",
+        "requested": "[5.0.2, )",
+        "resolved": "5.0.2",
+        "contentHash": "Jlgnmh7kSgvBK4AwUjOq0NM/fBUJFcJjuvTFiosaGj7vamFWHIVc6N/efzgCu/woLXZBIBs5XnYGBDl7ZcjDcA==",
         "dependencies": {
           "Cake.Core": "5.0.0",
-          "Microsoft.Identity.Client": "4.66.2",
+          "Microsoft.Identity.Client": "4.72.1",
           "Microsoft.TeamFoundationServer.Client": "19.225.1",
           "Microsoft.VisualStudio.Services.InteractiveClient": "19.225.1",
           "System.Data.SqlClient": "4.9.0",
@@ -1286,8 +1286,8 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.66.2",
-        "contentHash": "OsWRWpJs5iY9DxAF7DfWRGVNeFhjz75x+/bpHKB9Hbnu3THUgqYfQrYeQMgwx30ctweiV7h00aQpEua2kLeUpg==",
+        "resolved": "4.72.1",
+        "contentHash": "U3FbgYeKbU34zP17vi4xO70U5WiVO4GcqHbGwfqzAGJMQQfzkdEK5Ue69mI1tWj7Ft2lbJJ9Wsho9/6Jn5OKqQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="Cake.Common" Version="5.0.0" />
     <PackageVersion Include="Cake.Core" Version="5.0.0" />
-    <PackageVersion Include="Cake.Frosting.AzureDevOps" Version="5.0.0" />
+    <PackageVersion Include="Cake.Frosting.AzureDevOps" Version="5.0.2" />
     <PackageVersion Include="Cake.Testing" Version="5.0.0" />
     <PackageVersion Include="Errata" Version="0.14.0" />
     <PackageVersion Include="Gazorator" Version="0.5.2" />


### PR DESCRIPTION
Builds against and requires Cake.AzureDevOps 5.0.2 to avoid package being deleted on nuget.org.

See https://github.com/cake-contrib/Cake.Issues/issues/1153 for details.