### PR TITLE
Enforce Copilot to build documentation before committing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,7 @@ Follow these guidelines when contributing:
 - Ensure no warning or error messages from Roslyn analyzers are present in the code.
 - Ensure Tests are passing.
 - Ensure Integration Tests for the affected addins are passing.
+- If documentation has been changed, ensure it builds successfully.
 
 ## Development Flow
 - Only building: `build.sh --target=DotNetCore-Build`


### PR DESCRIPTION
Update instructions for Copilot to have it build documentation before committing