### PR TITLE
Mention support for issues summary when running on GitHub Actions

### DIFF
--- a/docs/input/documentation/recipe/supported-tools.md
+++ b/docs/input/documentation/recipe/supported-tools.md
@@ -80,7 +80,7 @@ Cake.Issues recipes integrates with the following build systems:
     <div class="annotate" markdown>
 
     - [x] Write issues to build server
-    - [ ] Issues summary
+    - [x] Issues summary
     - [x] SARIF report (1)
     - [ ] Full issues report
 


### PR DESCRIPTION
Mention support for issues summary when running on GitHub Actions as implemented with https://github.com/cake-contrib/Cake.Issues.Recipe/pull/611