### PR TITLE
Mention support for full issues report when running on GitHub Actions

### DIFF
--- a/docs/input/documentation/recipe/supported-tools.md
+++ b/docs/input/documentation/recipe/supported-tools.md
@@ -82,7 +82,7 @@ Cake.Issues recipes integrates with the following build systems:
     - [x] Write issues to build server
     - [x] Issues summary
     - [x] SARIF report (1)
-    - [ ] Full issues report
+    - [x] Full issues report
 
     </div>
 


### PR DESCRIPTION
Mention support for upload of full issues report when running on GitHub Actions as implemented with https://github.com/cake-contrib/Cake.Issues.Recipe/issues/376