### PR TITLE
(GH-1303) Add documentation IIssue.Snippet and IIssue.SourceLanguage property

### DIFF
--- a/docs/input/documentation/issue-providers/docfx/features.md
+++ b/docs/input/documentation/issue-providers/docfx/features.md
@@ -39,6 +39,8 @@ provides the following features.
 * [x] `IIssue.PriorityName`
 * [x] `IIssue.RuleId`
 * [x] `IIssue.RuleUrl`
+* [ ] `IIssue.Snippet`
+* [ ] `IIssue.SourceLanguage`
 
 </div>
 

--- a/docs/input/documentation/issue-providers/eslint/features.md
+++ b/docs/input/documentation/issue-providers/eslint/features.md
@@ -48,6 +48,8 @@ following features.
 * [x] `IIssue.PriorityName`
 * [x] `IIssue.RuleId`
 * [x] `IIssue.RuleUrl` (4)
+* [ ] `IIssue.Snippet`
+* [ ] `IIssue.SourceLanguage`
 
 </div>
 

--- a/docs/input/documentation/issue-providers/gitrepository/features.md
+++ b/docs/input/documentation/issue-providers/gitrepository/features.md
@@ -38,6 +38,8 @@ provides the following features.
 * [x] `IIssue.PriorityName`
 * [x] `IIssue.RuleId`
 * [x] `IIssue.RuleUrl`
+* [ ] `IIssue.Snippet`
+* [ ] `IIssue.SourceLanguage`
 
 </div>
 

--- a/docs/input/documentation/issue-providers/inspectcode/features.md
+++ b/docs/input/documentation/issue-providers/inspectcode/features.md
@@ -49,6 +49,8 @@ The [Cake.Issues.InspectCode addin] provides the following features.
 * [x] `IIssue.PriorityName`
 * [x] `IIssue.RuleId`
 * [x] `IIssue.RuleUrl`
+* [ ] `IIssue.Snippet`
+* [ ] `IIssue.SourceLanguage`
 
 </div>
 

--- a/docs/input/documentation/issue-providers/markdownlint/features.md
+++ b/docs/input/documentation/issue-providers/markdownlint/features.md
@@ -58,7 +58,9 @@ provides the following features.
     * [x] `IIssue.PriorityName` (5)
     * [x] `IIssue.RuleId`
     * [x] `IIssue.RuleUrl` (6)
-    
+    * [ ] `IIssue.Snippet`
+    * [ ] `IIssue.SourceLanguage`
+  
     </div>
     
     1. Can be set while reading issues
@@ -92,6 +94,8 @@ provides the following features.
     * [x] `IIssue.PriorityName` (5)
     * [x] `IIssue.RuleId`
     * [x] `IIssue.RuleUrl` (6)
+    * [ ] `IIssue.Snippet`
+    * [ ] `IIssue.SourceLanguage`
     
     </div>
     
@@ -126,6 +130,8 @@ provides the following features.
     * [x] `IIssue.PriorityName` (5)
     * [x] `IIssue.RuleId`
     * [x] `IIssue.RuleUrl`
+    * [ ] `IIssue.Snippet`
+    * [ ] `IIssue.SourceLanguage`
     
     </div>
     

--- a/docs/input/documentation/issue-providers/msbuild/features.md
+++ b/docs/input/documentation/issue-providers/msbuild/features.md
@@ -51,6 +51,8 @@ provides the following features.
     * [x] `IIssue.PriorityName`
     * [x] `IIssue.RuleId`
     * [x] `IIssue.RuleUrl` (4)
+    * [ ] `IIssue.Snippet`
+    * [ ] `IIssue.SourceLanguage`
     
     </div>
     
@@ -85,6 +87,8 @@ provides the following features.
     - [x] `IIssue.PriorityName`
     - [x] `IIssue.RuleId`
     - [x] `IIssue.RuleUrl` (4)
+    - [ ] `IIssue.Snippet`
+    - [ ] `IIssue.SourceLanguage`
     
     </div>
     

--- a/docs/input/documentation/issue-providers/sarif/features.md
+++ b/docs/input/documentation/issue-providers/sarif/features.md
@@ -36,6 +36,8 @@ following features.
 * [x] `IIssue.PriorityName`
 * [x] `IIssue.RuleId`
 * [x] `IIssue.RuleUrl`
+* [ ] `IIssue.Snippet`
+* [ ] `IIssue.SourceLanguage`
 
 </div>
 

--- a/docs/input/documentation/issue-providers/tap/features.md
+++ b/docs/input/documentation/issue-providers/tap/features.md
@@ -56,6 +56,8 @@ features.
     - [ ] `IIssue.PriorityName`
     - [ ] `IIssue.RuleId`
     - [ ] `IIssue.RuleUrl`
+    - [ ] `IIssue.Snippet`
+    - [ ] `IIssue.SourceLanguage`
     
     </div>
     
@@ -87,6 +89,8 @@ features.
     - [x] `IIssue.PriorityName`
     - [x] `IIssue.RuleId`
     - [x] `IIssue.RuleUrl` (4)
+    - [ ] `IIssue.Snippet`
+    - [ ] `IIssue.SourceLanguage`
     
     </div>
     
@@ -119,6 +123,8 @@ features.
     - [x] `IIssue.PriorityName`
     - [x] `IIssue.RuleId`
     - [x] `IIssue.RuleUrl` (4)
+    - [ ] `IIssue.Snippet`
+    - [ ] `IIssue.SourceLanguage`
     
     </div>
     

--- a/docs/input/documentation/issue-providers/terraform/features.md
+++ b/docs/input/documentation/issue-providers/terraform/features.md
@@ -38,6 +38,8 @@ The [Cake.Issues.Terraform addin] provides the following features.
 * [x] `IIssue.PriorityName`
 * [x] `IIssue.RuleId`
 * [x] `IIssue.RuleUrl`
+* [ ] `IIssue.Snippet`
+* [ ] `IIssue.SourceLanguage`
 
 </div>
 


### PR DESCRIPTION
Adds documentation for the `IIssue.Snippet` and `IIssue.SourceLanguage` property to the issue provider documentation.

Fixes #1303 