### PR TITLE
Enable instant prefetching

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,7 @@ theme:
     - content.tooltips
     - navigation.indexes 
     - navigation.instant
+    - navigation.instant.prefetch
     - navigation.instant.progress
     - navigation.sections
     - navigation.tabs


### PR DESCRIPTION
Enable [Instant Prefetching](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-prefetching).

Instant prefetching is a feature that will start to fetch a page once the user hovers over a link. This will reduce the perceived loading time for the user, especially on slow connections, as the page will be available immediately upon navigation.