### PR TITLE
Enable breadcrumb

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -60,6 +60,7 @@ theme:
     - navigation.indexes 
     - navigation.instant
     - navigation.instant.progress
+    - navigation.path
     - navigation.sections
     - navigation.tabs
     - navigation.tabs.sticky


### PR DESCRIPTION
Enables a breadcrumb navigation above the title of each page, which might make orientation easier for users visiting your documentation on devices with smaller screens.