### PR TITLE
Add support for Markdownlint 0.46.0 format

### DIFF
--- a/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
+++ b/src/Cake.Issues.Markdownlint.Tests/LogFileFormat/MarkdownlintCliLogFileFormatTests.cs
@@ -504,5 +504,94 @@ public sealed class MarkdownlintCliLogFileFormatTests
                     .OfRule("MD047", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md047"))
                     .WithPriority(IssuePriority.Warning));
         }
+
+        [Fact]
+        public void Should_Read_Issue_Correct_0_46_0()
+        {
+            // Given
+            var fixture =
+                new MarkdownlintIssuesProviderFixture<MarkdownlintCliLogFileFormat>("markdownlint-cli-0.46.0.log")
+                {
+                    ReadIssuesSettings = new ReadIssuesSettings("C:/git/github/cake-contrib/Cake.Issues.Markdownlint/tests"),
+                };
+
+            // When
+            var issues = fixture.ReadIssues().ToList();
+
+            // Then
+            issues.Count.ShouldBe(8);
+            IssueChecker.Check(
+                issues[0],
+                IssueBuilder.NewIssue(
+                    "Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: \"# foo\"]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 1)
+                    .OfRule("MD022", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[1],
+                IssueBuilder.NewIssue(
+                    "Trailing spaces [Expected: 0 or 2; Actual: 1]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 2, 811)
+                    .OfRule("MD009", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[2],
+                IssueBuilder.NewIssue(
+                    "Line length [Expected: 100; Actual: 811]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 2, 101)
+                    .OfRule("MD013", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[3],
+                IssueBuilder.NewIssue(
+                    "Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: \"# bar\"]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 4)
+                    .OfRule("MD022", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[4],
+                IssueBuilder.NewIssue(
+                    "Multiple top-level headings in the same document [Context: \"bar\"]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 4)
+                    .OfRule("MD025", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md025"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[5],
+                IssueBuilder.NewIssue(
+                    "Fenced code blocks should be surrounded by blank lines [Context: \"```\"]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 5)
+                    .OfRule("MD031", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md031"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[6],
+                IssueBuilder.NewIssue(
+                    "Fenced code blocks should have a language specified [Context: \"```\"]",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 5)
+                    .OfRule("MD040", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md040"))
+                    .WithPriority(IssuePriority.Warning));
+            IssueChecker.Check(
+                issues[7],
+                IssueBuilder.NewIssue(
+                    "Files should end with a single newline character",
+                    "Cake.Issues.Markdownlint.MarkdownlintIssuesProvider",
+                    "markdownlint")
+                    .InFile("docs/index.md", 7, 3)
+                    .OfRule("MD047", new Uri("https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md047"))
+                    .WithPriority(IssuePriority.Warning));
+        }
     }
 }

--- a/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliLogFileFormat/markdownlint-cli-0.46.0.log
+++ b/src/Cake.Issues.Markdownlint.Tests/Testfiles/MarkdownlintCliLogFileFormat/markdownlint-cli-0.46.0.log
@@ -1,0 +1,8 @@
+docs/index.md:1 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "# foo"]
+docs/index.md:2:811 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
+docs/index.md:2:101 MD013/line-length Line length [Expected: 100; Actual: 811]
+docs/index.md:4 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "# bar"]
+docs/index.md:4 MD025/single-title/single-h1 Multiple top-level headings in the same document [Context: "bar"]
+docs/index.md:5 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
+docs/index.md:5 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
+docs/index.md:7:3 MD047/single-trailing-newline Files should end with a single newline character

--- a/src/Cake.Issues.Tests/StringPathExtensionsTests.cs
+++ b/src/Cake.Issues.Tests/StringPathExtensionsTests.cs
@@ -652,6 +652,25 @@ public sealed class StringPathExtensionsTests
             // Then
             filePathResult.ShouldBe(expectedResult);
         }
+
+        [Theory]
+        [InlineData(@"C:\repo", @"foo", "foo")]
+        [InlineData(@"C:\repo", @"foo\", @"foo\")]
+        [InlineData(@"C:\repo", @"foo\bar", @"foo\bar")]
+        [InlineData("/repo", "foo", "foo")]
+        [InlineData("/repo", "foo/", "foo/")]
+        [InlineData("/repo", "foo/bar", "foo/bar")]
+        public void Should_Handle_AbsolutePaths(string repoRoot, string filePath, string expectedResult)
+        {
+            // Given
+            var repositorySettings = new RepositorySettings(repoRoot);
+
+            // When
+            var (_, filePathResult) = filePath.IsValidRepositoryFilePath(repositorySettings);
+
+            // Then
+            filePathResult.ShouldBe(expectedResult);
+        }
     }
 
     public sealed class TheIsInRepositoryExtension

--- a/src/Cake.Issues/StringPathExtensions.cs
+++ b/src/Cake.Issues/StringPathExtensions.cs
@@ -154,6 +154,12 @@ public static class StringPathExtensions
         filePath.NotNullOrWhiteSpace();
         repositorySettings.NotNull();
 
+        // If path is already relative, return it as is.
+        if (new Core.IO.FilePath(filePath).IsRelative)
+        {
+            return (true, filePath);
+        }
+
         // Ignore files from outside the repository.
         if (!filePath.IsInRepository(repositorySettings))
         {


### PR DESCRIPTION
Starting with markdownlint-cli 0.46.0 file paths are reported as relative instead of absolute paths. This PR updates logic to be able to handle absolute and relative paths. 