### PR TITLE
Revert to Cake Recipe 4 

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "3.2.0",
+      "version": "2.3.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://pkgs.dev.azure.com/cake-contrib/Home/_packaging/addins/nuget/v3/index.json?package=Cake.Recipe&version=4.1.0-alpha0042
+#load nuget:?package=Cake.Recipe&version=4.0.0
 
 //*************************************************************************************************
 // Settings
@@ -39,7 +39,7 @@ Setup(context =>
     // Addins are backwards compatible to latest major version.
     // Since we are using project references, we need to fix assembly version to the latest
     // major version to avoid requiring exact minor versions at runtime.
-    var settings = context.Data.Get<DotNetMSBuildSettings>();
+    var settings = context.Data.Get<DotNetCoreMSBuildSettings>();
     var version = new Version(settings.Properties["AssemblyVersion"].First());
     settings.Properties["AssemblyVersion"] = new List<string> { $"{version.Major}.0.0.0" };
 
@@ -52,8 +52,8 @@ Setup(context =>
 
 // Since Cake.Recipe does not detect the correct settings when using Directory.Build.props we need
 // to override the test task
-((CakeTask)BuildParameters.Tasks.DotNetTestTask.Task).Actions.Clear();
-BuildParameters.Tasks.DotNetTestTask.Does<DotNetMSBuildSettings>((context, msBuildSettings) => {
+((CakeTask)BuildParameters.Tasks.DotNetCoreTestTask.Task).Actions.Clear();
+BuildParameters.Tasks.DotNetCoreTestTask.Does<DotNetCoreMSBuildSettings>((context, msBuildSettings) => {
     var projects = GetFiles(BuildParameters.TestDirectoryPath + (BuildParameters.TestFilePattern ?? "/**/*Tests.csproj"));
     // We create the coverlet settings here so we don't have to create the filters several times
     var coverletSettings = new CoverletSettings
@@ -77,7 +77,7 @@ BuildParameters.Tasks.DotNetTestTask.Does<DotNetMSBuildSettings>((context, msBui
             coverletSettings.WithFilter(filter.TrimStart('-'));
         }
     }
-    var settings = new DotNetTestSettings
+    var settings = new DotNetCoreTestSettings
     {
         Configuration = BuildParameters.Configuration,
         NoBuild = true
@@ -94,7 +94,7 @@ BuildParameters.Tasks.DotNetTestTask.Does<DotNetMSBuildSettings>((context, msBui
         };
 
         coverletSettings.CoverletOutputName = parsedProject.RootNameSpace.Replace('.', '-');
-        DotNetTest(project.FullPath, settings, coverletSettings);
+        DotNetCoreTest(project.FullPath, settings, coverletSettings);
     }
 });
 
@@ -104,7 +104,7 @@ BuildParameters.Tasks.UploadCodecovReportTask
     .WithCriteria(() => BuildParameters.IsMainRepository, "Skipping because not running from the main repository")
     .WithCriteria(() => BuildParameters.ShouldRunCodecov, "Skipping because uploading to codecov is disabled")
     .WithCriteria(() => BuildParameters.CanPublishToCodecov, "Skipping because repo token is missing, or not running on GitHub CI")
-    .Does<BuildVersion>((context, buildVersion) => RequireTool(ToolSettings.CodecovGlobalTool, () => {
+    .Does<BuildVersion>((context, buildVersion) => RequireTool(BuildParameters.IsDotNetCoreBuild ? ToolSettings.CodecovGlobalTool : ToolSettings.CodecovTool, () => {
         var coverageFiles = GetFiles(BuildParameters.Paths.Directories.TestCoverage + "/coverlet/*.net9.0.opencover.xml");
         if (FileExists(BuildParameters.Paths.Files.TestCoverageOutputFilePath))
         {
@@ -181,4 +181,4 @@ IssuesBuildTasks.IssuesTask
 // Execution
 //*************************************************************************************************
 
-Build.RunDotNet();
+Build.RunDotNetCore();


### PR DESCRIPTION
Reverts to Cake Recipe 4, since AppVeyor build is broken.

This reverts PR #1285 / commit fec7ad9418d948010befc74f0f53f4a71fe1951f.