### PR TITLE
Fetch full history on checkout and fix GitVersion detached HEAD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Get the sources
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 0
+          fetch-tags: true
           lfs: true
-      - name: Fetch all tags and branches
-        run: git fetch --prune --unshallow
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,8 +25,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Fetch all tags and branches
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:

--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -21,8 +21,9 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Fetch all tags and branches
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:

--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Create local branch for GitVersion
+        if: github.event_name == 'pull_request'
+        run: git checkout -b ${{ github.head_ref }}
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Create local branch for GitVersion
+        if: github.event_name == 'pull_request'
+        run: git checkout -b ${{ github.head_ref }}
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,8 +28,9 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Fetch all tags and branches
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Install .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:


### PR DESCRIPTION
Fetch full history and tags directly on checkout instead through a separate call.

GitHub Actions checks out a PR as a detached merge commit. GitVersion finds no local branch, then attempts to resolve the PR ref by connecting to the remote via LibGit2Sharp — which fails with `this remote has never connected`.

Fix: create a named local branch after the fetch step so GitVersion resolves the version without a remote connection:

```yaml
- name: Create local branch for GitVersion
  if: github.event_name == 'pull_request'
  run: git checkout -b ${{ github.head_ref }}
```