### PR TITLE
Run doc preview workflow on Node 20

### DIFF
--- a/.github/workflows/pushpreview.yml
+++ b/.github/workflows/pushpreview.yml
@@ -32,6 +32,8 @@ jobs:
           mkdocs build
       - name: Generate preview
         uses: PushLabsHQ/pushpreview-action@cf958f7be2bf55d3f56d351bb9abf56b4c6b9a50 # 1.0.6
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
         with:
           source-directory: ./docs/site
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
pushpreview-action is still on Node 20 and not compatibile with Node 24. This PR allows to run the action on Node 20.